### PR TITLE
Protobuf docs

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -91,6 +91,17 @@ services:
         python3 -m remme.rest_api
       "
 
+  remme-proto-docs:
+    image: pseudomuto/protoc-gen-doc
+    volumes:
+      - .protos:/protos
+      - .docs:/out
+    entrypoint: |
+      bash -c "
+        tail -f /dev/null
+      "
+#      protoc-gen-doc --doc_opt=markdown,proto-docs.md
+
   shell:
     image: remme/remme-core-dev:latest
     depends_on:


### PR DESCRIPTION
This PR is blocked on https://github.com/pseudomuto/protoc-gen-doc/issues/353 
It is highly recommended to reconsider the need for separate protobuf models documentation generation.
The current code is aiming to be self-descriptive.