### PR TITLE
Rem 19 rest api

### DIFF
--- a/remme/rest_api/certificate.py
+++ b/remme/rest_api/certificate.py
@@ -26,7 +26,7 @@ from remme.rest_api.certificate_api_decorator import certificate_put_request,\
 from remme.shared.exceptions import KeyNotFound
 
 
-@http_payload_required('certificate')
+@http_payload_required
 @certificate_address_request
 def post(certificate_address):
     client = CertificateClient()
@@ -38,7 +38,7 @@ def post(certificate_address):
         return NoContent, 404
 
 
-@http_payload_required('certificate')
+@http_payload_required
 @certificate_address_request
 def delete(certificate_address):
     client = CertificateClient()
@@ -52,7 +52,7 @@ def delete(certificate_address):
         return NoContent, 404
 
 
-@http_payload_required()
+@http_payload_required
 @certificate_put_request
 def put(cert, key, key_export):
     certificate_client = CertificateClient()

--- a/remme/rest_api/certificate.py
+++ b/remme/rest_api/certificate.py
@@ -14,111 +14,53 @@
 # ------------------------------------------------------------------------
 
 import re
-import datetime
 import hashlib
 from connexion import NoContent
 from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa, padding
-from cryptography.hazmat.backends import default_backend
-from cryptography import x509
-from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives import hashes
 
 from remme.certificate.certificate_client import CertificateClient
+from remme.rest_api.certificate_api_decorator import certificate_put_request,\
+    http_payload_required, certificate_address_request
 from remme.shared.exceptions import KeyNotFound
 
 
-def _make_address_from_pem(client, certificate_pem):
-    certificate = x509.load_pem_x509_certificate(certificate_pem.encode('utf-8'),
-                                                 default_backend())
-    crt_bin = certificate.public_bytes(serialization.Encoding.DER).hex()
-    address = client.make_address_from_data(crt_bin)
-    return address
-
-
-def post(payload):
+@http_payload_required('certificate')
+@certificate_address_request
+def post(certificate_address):
     client = CertificateClient()
-    address = _make_address_from_pem(client, payload['certificate'])
     try:
-        certificate_data = client.get_status(address)
+        certificate_data = client.get_status(certificate_address)
         return {'revoked': certificate_data.revoked,
                 'owner': certificate_data.owner}
     except KeyNotFound:
         return NoContent, 404
 
 
-def delete(payload):
+@http_payload_required('certificate')
+@certificate_address_request
+def delete(certificate_address):
     client = CertificateClient()
-    address = _make_address_from_pem(client, payload['certificate'])
     try:
-        certificate_data = client.get_status(address)
+        certificate_data = client.get_status(certificate_address)
         if certificate_data.revoked:
-            return {'error': 'The certificate was already revoked'}, 500
-        client.revoke_certificate(address)
-        return {}
+            return {'error': 'The certificate was already revoked'}, 409
+        client.revoke_certificate(certificate_address)
+        return NoContent, 204
     except KeyNotFound:
         return NoContent, 404
 
 
-def put(payload):
-    parameters = {
-        'country_name': NameOID.COUNTRY_NAME,
-        'state_name': NameOID.STATE_OR_PROVINCE_NAME,
-        'locality_name': NameOID.LOCALITY_NAME,
-        'common_name': NameOID.COMMON_NAME,
-        'name': NameOID.GIVEN_NAME,
-        'surname': NameOID.SURNAME,
-        'email': NameOID.EMAIL_ADDRESS
-    }
-
-    client = CertificateClient()
-
-    encryption_algorithm = serialization.NoEncryption()
-    if 'passphrase' in payload.keys():
-        if payload['passphrase']:
-            encryption_algorithm = serialization.BestAvailableEncryption(
-                payload['passphrase'].encode('utf-8'))
-
-    key = rsa.generate_private_key(
-        public_exponent=65537,
-        key_size=2048,
-        backend=default_backend()
-    )
-
-    key_export = key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.TraditionalOpenSSL,
-        encryption_algorithm=encryption_algorithm
-    )
-
-    name_oid = [x509.NameAttribute(NameOID.ORGANIZATION_NAME, 'REMME'),
-                x509.NameAttribute(NameOID.USER_ID, client.get_signer_pubkey())]
-
-    for k, v in parameters.items():
-        if k in payload.keys():
-            name_oid.append(x509.NameAttribute(v, payload[k]))
-
-    subject = issuer = x509.Name(name_oid)
-    cert = x509.CertificateBuilder().subject_name(
-        subject
-    ).issuer_name(
-        issuer
-    ).public_key(
-        key.public_key()
-    ).serial_number(
-        x509.random_serial_number()
-    ).not_valid_before(
-        datetime.datetime.utcnow()
-    ).not_valid_after(
-        datetime.datetime.utcnow() + datetime.timedelta(days=payload['validity'])
-    ).sign(key, hashes.SHA256(), default_backend())
+@http_payload_required()
+@certificate_put_request
+def put(cert, key, key_export):
+    certificate_client = CertificateClient()
 
     crt_export = cert.public_bytes(serialization.Encoding.PEM)
-
     crt_bin = cert.public_bytes(serialization.Encoding.DER).hex()
     crt_hash = hashlib.sha512(crt_bin.encode('utf-8')).hexdigest()
-    rem_sig = client.sign_text(crt_hash)
-
+    rem_sig = certificate_client.sign_text(crt_hash)
     crt_sig = key.sign(
         bytes.fromhex(rem_sig),
         padding.PSS(
@@ -128,7 +70,7 @@ def put(payload):
         hashes.SHA256()
     )
 
-    status, _ = client.store_certificate(crt_bin, rem_sig, crt_sig.hex())
+    status, _ = certificate_client.store_certificate(crt_bin, rem_sig, crt_sig.hex())
 
     return {'certificate': crt_export.decode('utf-8'),
             'priv_key': key_export.decode('utf-8'),

--- a/remme/rest_api/certificate_api_decorator.py
+++ b/remme/rest_api/certificate_api_decorator.py
@@ -46,22 +46,17 @@ def certificate_address_request(func):
     return validation_logic
 
 
-def http_payload_required(tag_name=None):
-    def method_decorator(func):
-        def func_wrapper(payload):
-            if payload is None:
-                return {'error': 'Http request body can not be empty'}, 422
-            if tag_name:
-                try:
-                    payload[tag_name]
-                except KeyError:
-                    return {'error': 'Http request body should contain {} parameter'.format(tag_name)}, 422
+# hot fix - as far as connexion has a bug inside it is
+# temp solution for null body cases
+# https://github.com/zalando/connexion/issues/579
+def http_payload_required(func):
+    def func_wrapper(payload):
+        if payload is None:
+            return {'error': 'Http request body can not be empty'}, 422
 
-            return func(payload)
+        return func(payload)
 
-        return func_wrapper
-
-    return method_decorator
+    return func_wrapper
 
 
 # endregion

--- a/remme/rest_api/certificate_api_decorator.py
+++ b/remme/rest_api/certificate_api_decorator.py
@@ -14,7 +14,6 @@ from cryptography.hazmat.primitives.asymmetric import rsa, padding
 import datetime
 
 
-# region Certificate HTTP API attributes
 def certificate_put_request(func):
     def validation_logic(payload):
         cert, key, key_export = create_certificate(payload)
@@ -59,10 +58,6 @@ def http_payload_required(func):
     return func_wrapper
 
 
-# endregion
-
-# region Certificate Creation
-
 def create_certificate(payload):
     parameters = get_params()
     encryption_algorithm = get_encryption_algorithm(payload)
@@ -99,9 +94,6 @@ def build_certificate(parameters, payload, key):
     ).sign(key, hashes.SHA256(), default_backend())
 
 
-# endregion
-
-# region Helpers
 def get_params():
     return {
         'country_name': NameOID.COUNTRY_NAME,
@@ -139,9 +131,6 @@ def generate_key_export(key, encryption_algorithm):
     )
 
 
-# endregion
-
-# region Validation Methods
 def is_valid_token_balance():
     token_client = TokenClient()
     signer_pub_key = token_client.get_signer().get_public_key().as_hex()
@@ -157,4 +146,3 @@ def certificate_already_exist(cert):
     except KeyNotFound:
         return False
     return True
-# endregion

--- a/remme/rest_api/certificate_api_decorator.py
+++ b/remme/rest_api/certificate_api_decorator.py
@@ -1,0 +1,165 @@
+from remme.certificate.certificate_handler import CERT_STORE_PRICE, CERT_ORGANIZATION, CERT_MAX_VALIDITY
+
+from remme.token.token_client import TokenClient
+from remme.token.token_handler import TokenHandler
+from remme.shared.exceptions import KeyNotFound
+
+from remme.certificate.certificate_client import CertificateClient
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.backends import default_backend
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import rsa, padding
+import datetime
+
+
+# region Certificate HTTP API attributes
+def certificate_put_request(func):
+    def validation_logic(payload):
+        cert, key, key_export = create_certificate(payload)
+
+        if not is_valid_token_balance():
+            return {'error': 'You have no tokens to issue certificate'}, 402
+        if certificate_already_exist(cert):
+            return {'error': 'This certificate is already registered'}, 409
+        if cert.not_valid_after - cert.not_valid_before > CERT_MAX_VALIDITY:
+            return {'error': 'The certificate validity exceeds the maximum value'}, 400
+
+        return func(cert, key, key_export)
+
+    return validation_logic
+
+
+def certificate_address_request(func):
+    def validation_logic(payload):
+        try:
+            certificate = x509.load_pem_x509_certificate(payload['certificate'].encode('utf-8'),
+                                                         default_backend())
+            crt_bin = certificate.public_bytes(serialization.Encoding.DER).hex()
+            address = CertificateClient().make_address_from_data(crt_bin)
+        except ValueError:
+            return {'error': 'Unable to load certificate entity'}, 422
+
+        return func(address)
+
+    return validation_logic
+
+
+def http_payload_required(tag_name=None):
+    def method_decorator(func):
+        def func_wrapper(payload):
+            if payload is None:
+                return {'error': 'Http request body can not be empty'}, 422
+            if tag_name:
+                try:
+                    payload[tag_name]
+                except KeyError:
+                    return {'error': 'Http request body should contain {} parameter'.format(tag_name)}, 422
+
+            return func(payload)
+
+        return func_wrapper
+
+    return method_decorator
+
+
+# endregion
+
+# region Certificate Creation
+
+def create_certificate(payload):
+    parameters = get_params()
+    encryption_algorithm = get_encryption_algorithm(payload)
+
+    key = generate_key()
+    key_export = generate_key_export(key, encryption_algorithm)
+    cert = build_certificate(parameters, payload, key)
+
+    return cert, key, key_export
+
+
+def build_certificate(parameters, payload, key):
+    name_oid = [x509.NameAttribute(NameOID.ORGANIZATION_NAME, CERT_ORGANIZATION),
+                x509.NameAttribute(NameOID.USER_ID, CertificateClient().get_signer_pubkey())]
+
+    for k, v in parameters.items():
+        if k in payload.keys():
+            name_oid.append(x509.NameAttribute(v, payload[k]))
+
+    subject = issuer = x509.Name(name_oid)
+
+    return x509.CertificateBuilder().subject_name(
+        subject
+    ).issuer_name(
+        issuer
+    ).public_key(
+        key.public_key()
+    ).serial_number(
+        x509.random_serial_number()
+    ).not_valid_before(
+        datetime.datetime.utcnow()
+    ).not_valid_after(
+        datetime.datetime.utcnow() + datetime.timedelta(days=payload['validity'])
+    ).sign(key, hashes.SHA256(), default_backend())
+
+
+# endregion
+
+# region Helpers
+def get_params():
+    return {
+        'country_name': NameOID.COUNTRY_NAME,
+        'state_name': NameOID.STATE_OR_PROVINCE_NAME,
+        'locality_name': NameOID.LOCALITY_NAME,
+        'common_name': NameOID.COMMON_NAME,
+        'name': NameOID.GIVEN_NAME,
+        'surname': NameOID.SURNAME,
+        'email': NameOID.EMAIL_ADDRESS
+    }
+
+
+def get_encryption_algorithm(payload):
+    encryption_algorithm = serialization.NoEncryption()
+    if 'passphrase' in payload.keys():
+        if payload['passphrase']:
+            encryption_algorithm = serialization.BestAvailableEncryption(
+                payload['passphrase'].encode('utf-8'))
+    return encryption_algorithm
+
+
+def generate_key():
+    return rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+        backend=default_backend()
+    )
+
+
+def generate_key_export(key, encryption_algorithm):
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=encryption_algorithm
+    )
+
+
+# endregion
+
+# region Validation Methods
+def is_valid_token_balance():
+    token_client = TokenClient()
+    signer_pub_key = token_client.get_signer().get_public_key().as_hex()
+    signer_balance = token_client.get_balance(TokenHandler.make_address_from_data(signer_pub_key))
+    return signer_balance >= CERT_STORE_PRICE
+
+
+def certificate_already_exist(cert):
+    token_client = TokenClient()
+    address = token_client.make_address_from_data(cert.public_bytes(serialization.Encoding.DER).hex())
+    try:
+        value = token_client.get_value(address)
+    except KeyNotFound:
+        return False
+    return True
+# endregion

--- a/remme/rest_api/openapi.yml
+++ b/remme/rest_api/openapi.yml
@@ -255,6 +255,8 @@ parameters:
         certificate:
           description: PEM encoded certificate file
           type: string
+      required:
+        - certificate
   key_name_payload:
     name: payload
     in: body


### PR DESCRIPTION
REM-46 REST API: Make proper http error codes more common
REM-45 REST API: Make proper model validation for certificates

Main validation now located at certificate_api_decorator.py
The idea of it is separation of the controllers logic (revoke, store, check)
and additional validation/creation logic.  