### PR TITLE
Fix some Docker related issues & provide a command for Swagger documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F10
     apt-get install -y libssl-dev
 WORKDIR /root
 COPY ./bash/.bashrc /root/.bashrc
+COPY ./requirements.txt .
+RUN pip3 install -r ./requirements.txt
 RUN mkdir remme
 COPY . ./remme
-RUN pip3 install -r ./remme/requirements.txt
 RUN pip3 install ./remme

--- a/docker-compose/docs.yml
+++ b/docker-compose/docs.yml
@@ -17,10 +17,11 @@ version: '2.1'
 
 services:
   remme-docs:
+    build: ..
     image: remme/remme-core-dev:latest
     volumes:
-      - .:/root/remme
-      - ./README.rst:/root/remme/docs/README.rst
+      - ..:/root/remme
+      - ../README.rst:/root/remme/docs/README.rst
     ports:
       - '${REMME_DOCS_SERVER_PORT:-8000}:8000'
     env_file:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,8 +50,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
-    'sphinx.ext.githubpages',
-    'sphinxcontrib.openapi'
+    'sphinx.ext.githubpages'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/rest-api.rst
+++ b/docs/rest-api.rst
@@ -1,4 +1,0 @@
-REMME REST-API
-==============
-
-.. openapi:: ../remme/rest_api/openapi.yml

--- a/remme/rest_api/openapi.yml
+++ b/remme/rest_api/openapi.yml
@@ -13,6 +13,11 @@
 # limitations under the License.
 # ------------------------------------------------------------------------
 
+# TODO better resolver (remover operationId)
+
+# Generate documentation:
+# docker run -v $HOME/Projects/Work/Remme/remme-core/remme/rest_api:/docs swaggerapi/swagger-codegen-cli generate -i /docs/openapi.yml -l html2 -o /docs
+
 swagger: '2.0'
 
 info:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ sphinx
 sphinx-autobuild
 recommonmark
 sphinx_rtd_theme
-sphinxcontrib-openapi
 pyOpenSSL


### PR DESCRIPTION
- Fix reinstalling Python deps on each `make build_docker`.
- Fix paths for `remme-docs` service.
- Documentation can now be build with the command reflected in `openapi.yml`.