### PR TITLE
Fix Docker builds after python base image update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "protos"]
 	path = protos
-	url = git@github.com:Remmeauth/remme-protobuf.git
+	url = https://github.com/Remmeauth/remme-protobuf.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------
 
-FROM python:3.6
+FROM python:3.6.5-jessie
 WORKDIR /root
 COPY ./requirements.txt .
 RUN pip3 install -r ./requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------
 
+# TODO check if it works with a newer versio of Debian
 FROM python:3.6.5-jessie
 WORKDIR /root
 COPY ./requirements.txt .

--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,10 @@ test: build_docker
 build_protobuf:
 	protoc -I=$(PROTO_SRC_DIR) --python_out=$(PROTO_DST_DIR) $(PROTO_SRC_DIR)/*.proto
 
-build_docker: build_protobuf
+build_docker:
 	docker-compose -f docker-compose/dev.yml build
 
-rebuild_docker: build_protobuf
+rebuild_docker:
 	docker-compose -f docker-compose/dev.yml build --no-cache
 
 release: build_docker


### PR DESCRIPTION
Some devs encountered problems with building Docker containers on several platforms. A brief research has shown that the problem arises when building from `python:3.6.5-stretch` image provided by default. However, `python:3.6.5-jessie` worked just fine. The problem was with new versions of OpenSSL and some of Python libraries were incompatible with this versions (the provided image works with an older version of Debian). For now we will stick to this image but keep in mind that it is better to use newer versions of libraries, so we will need to check if it works before releases.