### PR TITLE
Refactor to use streams

### DIFF
--- a/docker-compose/test.yml
+++ b/docker-compose/test.yml
@@ -29,4 +29,6 @@ services:
   remme-tp:
     build: ..
     image: remme/remme-core:latest
+    environment:
+      IS_TESTING: "True"
     entrypoint: python3 -m remme.tp tcp://tests:4004

--- a/remme/settings/__init__.py
+++ b/remme/settings/__init__.py
@@ -1,3 +1,7 @@
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
 REST_API_URL = 'http://rest-api:8080'
 ZMQ_URL = 'tcp://validator:4004'
 KEY_DIR = '/root/.sawtooth/keys'

--- a/remme/tp/__main__.py
+++ b/remme/tp/__main__.py
@@ -14,6 +14,7 @@
 # ------------------------------------------------------------------------
 
 import argparse
+
 from sawtooth_sdk.processor.core import TransactionProcessor
 
 from remme.tp.atomic_swap import AtomicSwapHandler

--- a/remme/tp/atomic_swap.py
+++ b/remme/tp/atomic_swap.py
@@ -21,7 +21,7 @@ from remme.protos.atomic_swap_pb2 import AtomicSwapMethod, AtomicSwapInitPayload
     AtomicSwapApprovePayload, AtomicSwapExpirePayload, AtomicSwapSetSecretLockPayload, AtomicSwapClosePayload
 from remme.settings import SETTINGS_SWAP_COMMISSION, ZERO_ADDRESS
 from remme.settings.helper import _get_setting_value
-from remme.tp.basic import BasicHandler, get_data
+from remme.tp.basic import BasicHandler, get_data, add_event
 from remme.shared.utils import hash256
 from remme.clients.account import AccountClient
 from remme.tp.account import AccountHandler, get_account_by_address
@@ -147,9 +147,7 @@ class AtomicSwapHandler(BasicHandler):
                                                             transfer_payload)
         LOGGER.info("Save state")
 
-        context.add_event(
-            event_type=SWAP_INIT_EVENT,
-            attributes=[("status", "success")])
+        add_event(context, SWAP_INIT_EVENT, [("status", "success")])
 
         return {**self.get_state_update(swap_info),  **token_updated_state}
 

--- a/remme/tp/atomic_swap.py
+++ b/remme/tp/atomic_swap.py
@@ -26,6 +26,7 @@ from remme.shared.utils import hash256
 from remme.clients.account import AccountClient
 from remme.tp.account import AccountHandler, get_account_by_address
 from remme.shared.singleton import singleton
+from remme.ws.events import SWAP_INIT_EVENT
 
 LOGGER = logging.getLogger(__name__)
 
@@ -145,6 +146,10 @@ class AtomicSwapHandler(BasicHandler):
                                                             swap_info.sender_address,
                                                             transfer_payload)
         LOGGER.info("Save state")
+
+        context.add_event(
+            event_type=SWAP_INIT_EVENT,
+            attributes=[("status", "success")])
 
         return {**self.get_state_update(swap_info),  **token_updated_state}
 

--- a/remme/tp/basic.py
+++ b/remme/tp/basic.py
@@ -14,6 +14,10 @@
 # ------------------------------------------------------------------------
 
 import hashlib
+
+import logging
+import os
+
 from google.protobuf.text_format import ParseError
 from sawtooth_processor_test.message_factory import MessageFactory
 from sawtooth_sdk.processor.exceptions import InternalError
@@ -23,6 +27,7 @@ from sawtooth_sdk.processor.exceptions import InvalidTransaction
 from remme.protos.transaction_pb2 import TransactionPayload
 from remme.shared.utils import hash512
 
+LOGGER = logging.getLogger(__name__)
 
 def is_address(address):
     try:
@@ -32,6 +37,15 @@ def is_address(address):
         return True
     except (AssertionError, ValueError):
         return False
+
+
+def add_event(context, event_type, attributes):
+    IS_TESTING = bool(os.getenv('IS_TESTING', default=False))
+    if not IS_TESTING:
+        context.add_event(
+            event_type=event_type,
+            attributes=attributes)
+
 
 def get_data(context, pb_class, address):
     raw_data = context.get_state([address])

--- a/remme/ws/__main__.py
+++ b/remme/ws/__main__.py
@@ -20,6 +20,7 @@ from zmq.asyncio import ZMQEventLoop
 from sawtooth_sdk.messaging.stream import Stream
 from remme.settings import ZMQ_URL
 from remme.shared.logging import setup_logging
+from remme.ws.events import WSEventSocketHandler
 from .ws import WsApplicationHandler
 
 if __name__ == '__main__':
@@ -33,5 +34,7 @@ if __name__ == '__main__':
     app = web.Application(loop=loop)
     stream = Stream(ZMQ_URL)
     ws_handler = WsApplicationHandler(stream, loop=loop)
+    ws_event_handler = WSEventSocketHandler(stream, loop=loop)
+    app.router.add_route('GET', '/ws/events', ws_event_handler.subscriptions)
     app.router.add_route('GET', '/ws', ws_handler.subscriptions)
     web.run_app(app, host=arguments.bind, port=arguments.port)

--- a/remme/ws/basic.py
+++ b/remme/ws/basic.py
@@ -146,22 +146,12 @@ class BasicWebSocketHandler(object):
     def unsubscribe(self, entity, data):
         pass
 
-    async def _handle_unsubscribe(self, web_sock, payload=None):
+    async def _handle_unsubscribe(self, web_sock, data=None):
         with await self._subscriber_lock:
             if web_sock in self._subscribers:
                 del self._subscribers[web_sock]
 
-            if payload:
-                data = payload.get('data', {})
-
-                try:
-                    entity = Entity(payload['entity'])
-                except ValueError:
-                    await self._ws_send(web_sock, Status.INVALID_ENTITY, payload['id'])
-                    return
-
-                self.unsubscribe(web_sock, entity, data)
-            await self._ws_send(web_sock, Status.UNSUBSCRIBED, payload['id'])
+            await self._ws_send_message(web_sock, Status.UNSUBSCRIBED)
 
             LOGGER.info('Unsubscribed: %s', web_sock)
 

--- a/remme/ws/basic.py
+++ b/remme/ws/basic.py
@@ -1,0 +1,171 @@
+# Copyright 2018 REMME
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------
+
+import logging
+import asyncio
+import hashlib
+import weakref
+import re
+
+import aiohttp
+from aiohttp import web
+
+from .constants import Action, Entity, Status, Type
+from .utils import deserialize, serialize
+
+LOGGER = logging.getLogger(__name__)
+
+
+class BasicWebSocketHandler(object):
+
+    def __init__(self, stream, loop):
+        self._stream = stream
+        # mapping websocket => something valuable
+        self._subscribers = {}
+        self._subscriber_lock = asyncio.Lock()
+        self._accepting = True
+
+        self._loop = loop
+
+    async def on_shutdown(self):
+        await self._unregister_subscriptions()
+
+        self._accepting = False
+
+        for ws, _ in self._subscribers.items():
+            await ws.close(code=aiohttp.WSCloseCode.GOING_AWAY,
+                           message='Server shutdown')
+
+    async def subscriptions(self, request):
+        if not self._accepting:
+            return web.Response(status=503)
+
+        web_sock = web.WebSocketResponse()
+        await web_sock.prepare(request)
+
+        async for msg in web_sock:
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                await self._handle_message(web_sock, msg.data)
+            elif msg.type == aiohttp.WSMsgType.ERROR:
+                LOGGER.warning(
+                    'Web socket connection closed with exception %s',
+                    web_sock.exception())
+                await web_sock.close()
+
+        await self._handle_unsubscribe(web_sock)
+
+        return web_sock
+
+    def get_response_payload(self, type, data):
+        return {
+            'type': type,
+            'data': data
+        }
+
+    async def _ws_send_message(self, ws, data):
+        await self._ws_send(ws, self.get_response_payload(Type.MESSAGE, data))
+
+    async def _ws_send_error(self, ws, error):
+        await self._ws_send(ws, self.get_response_payload(Type.ERROR, error))
+
+    async def _ws_send(self, ws, payload):
+        return await ws.send_str(serialize(payload))
+
+    async def _handle_message(self, web_sock, message_content):
+        try:
+            LOGGER.info(f'Incoming message {message_content}')
+            payload = deserialize(message_content)
+        except Exception:
+            await self._ws_send_error(web_sock, Status.MALFORMED_JSON)
+            return
+
+        LOGGER.info('Got payload: %s' % payload)
+
+        err_code = self.validate_payload(payload)
+
+        if err_code:
+            await self._ws_send_error(web_sock, err_code)
+            return
+
+        try:
+            action = Action(payload['action'])
+        except ValueError:
+            await self._ws_send(web_sock, Status.INVALID_ACTION)
+            return
+
+        LOGGER.info('Determined action: %s', action)
+
+        data = payload['data']
+        if action == Action.SUBSCRIBE:
+            await self._handle_subscribe(web_sock, data)
+
+        elif action == Action.UNSUBSCRIBE:
+            await self._handle_unsubscribe(web_sock, data)
+
+    def validate_payload(self, payload):
+        action = payload.get('action')
+        if not action:
+            return Status.MISSING_ACTION
+        data = payload.get('data')
+        if not data:
+            return Status.MISSING_DATA
+        if action == Action.SUBSCRIBE:
+            if not data.get('entity'):
+                return Status.MISSING_ENTITY
+
+    async def _handle_subscribe(self, web_sock, data):
+        LOGGER.info('Sending initial most recent event to new subscriber')
+
+        try:
+            entity = Entity(data['entity'])
+        except ValueError:
+            await self._ws_send_error(web_sock, Status.INVALID_ENTITY)
+            return
+
+        with await self._subscriber_lock:
+            self._subscribers[web_sock] = self.subscribe(entity, data)
+            LOGGER.info('Subscribed: %s', web_sock)
+
+        await self._ws_send_message(web_sock, Status.SUBSCRIBED)
+
+    def subscribe(self, entity, data):
+        pass
+
+    def unsubscribe(self, entity, data):
+        pass
+
+    async def _handle_unsubscribe(self, web_sock, payload=None):
+        with await self._subscriber_lock:
+            if web_sock in self._subscribers:
+                del self._subscribers[web_sock]
+
+            if payload:
+                data = payload.get('data', {})
+
+                try:
+                    entity = Entity(payload['entity'])
+                except ValueError:
+                    await self._ws_send(web_sock, Status.INVALID_ENTITY, payload['id'])
+                    return
+
+                self.unsubscribe(web_sock, entity, data)
+            await self._ws_send(web_sock, Status.UNSUBSCRIBED, payload['id'])
+
+            LOGGER.info('Unsubscribed: %s', web_sock)
+
+    async def _handle_disconnect(self):
+        LOGGER.info('Validator disconnected')
+        for ws, _ in self._subscribers.items():
+            await self._ws_send(ws, Status.NO_VALIDATOR)

--- a/remme/ws/constants.py
+++ b/remme/ws/constants.py
@@ -32,6 +32,7 @@ class Entity(Enum):
 class Type(Enum):
     MESSAGE = 'message'
     ERROR = 'error'
+    STATUS = 'status'
 
 
 @unique

--- a/remme/ws/constants.py
+++ b/remme/ws/constants.py
@@ -25,8 +25,13 @@ class Action(Enum):
 
 @unique
 class Entity(Enum):
-
     BATCH_STATE = 'batch_state'
+    EVENTS = 'events'
+
+@unique
+class Type(Enum):
+    MESSAGE = 'message'
+    ERROR = 'error'
 
 
 @unique
@@ -69,5 +74,8 @@ class Status(IntEnum):
 
     # validator connection failed
     NO_VALIDATOR = 110
+
+    # missing data
+    MISSING_DATA = 111
 
     BATCH_RESPONSE = 200

--- a/remme/ws/events.py
+++ b/remme/ws/events.py
@@ -1,0 +1,103 @@
+import json
+
+import zmq
+import logging
+import weakref
+import asyncio
+
+from remme.settings import ZMQ_URL
+from sawtooth_sdk.protobuf.client_event_pb2 import ClientEventsSubscribeRequest
+from sawtooth_sdk.protobuf.validator_pb2 import Message
+from sawtooth_sdk.protobuf.events_pb2 import EventList, EventSubscription
+from google.protobuf.json_format import MessageToJson
+
+from remme.shared.utils import generate_random_key
+from remme.ws.basic import BasicWebSocketHandler
+from remme.ws.constants import Entity
+
+SWAP_INIT_EVENT = 'atomic-swap/init'
+
+LOGGER = logging.getLogger(__name__)
+
+
+class WSEventSocketHandler(BasicWebSocketHandler):
+    def __init__(self, stream, loop):
+        super().__init__(stream, loop)
+        self._events = [SWAP_INIT_EVENT]
+        self._events_updator_task = weakref.ref(
+            asyncio.ensure_future(
+                self.listen_events(), loop=self._loop))
+        self.subscribe_events()
+
+    # return what value to be mapped to web_sock
+    def subscribe(self, entity, data):
+        if entity == Entity.EVENTS:
+            events = data.get('events', [])
+            return {'events': events}
+
+    def unsubscribe(self, entity, data):
+        pass
+
+    def subscribe_events(self):
+        # Setup a connection to the validator
+        LOGGER.info(f"Subscribing to events")
+        ctx = zmq.Context()
+        self._socket = ctx.socket(zmq.DEALER)
+        self._socket.connect(ZMQ_URL)
+        LOGGER.info(f"Connected to ZMQ")
+
+        request = ClientEventsSubscribeRequest(subscriptions=self._make_subscriptions(), last_known_block_ids=[]).SerializeToString()
+
+        # Construct the message wrapper
+        correlation_id = generate_random_key()  # This must be unique for all in-process requests
+        msg = Message(
+            correlation_id=correlation_id,
+            message_type=Message.CLIENT_EVENTS_SUBSCRIBE_REQUEST,
+            content=request)
+
+        # Send the request
+        LOGGER.info(f"Sending subscription request.")
+        self._socket.send_multipart([msg.SerializeToString()])
+
+        LOGGER.info(f"Subscribed.")
+
+    # The following code listens for events and logs them indefinitely.
+    async def check_event(self):
+        LOGGER.info(f"Checking for new events...")
+
+        resp = None
+        try:
+            resp = self._socket.recv_multipart(flags=zmq.NOBLOCK)[-1]
+        except zmq.Again as e:
+            LOGGER.info("No message received yet")
+            return
+
+        # Parse the message wrapper
+        msg = Message()
+        msg.ParseFromString(resp)
+
+        LOGGER.info(f"message type {msg.message_type}")
+
+        # Validate the response type
+        if msg.message_type != Message.CLIENT_EVENTS:
+            LOGGER.info("Unexpected message type")
+            return
+
+        # Parse the response
+        event_list = EventList()
+        event_list.ParseFromString(msg.content)
+
+        for web_sock, _ in self._subscribers.items():
+            await self._ws_send_message(web_sock, {Entity.EVENTS: [json.loads(MessageToJson(event,
+                                                                           preserving_proto_field_name=True,
+                                                                           including_default_value_fields=True))
+                                                                   for event in event_list.events]})
+
+    async def listen_events(self, delta=5):
+        while True:
+            LOGGER.debug('Start events fetching...')
+            await asyncio.gather(*[self.check_event()])
+            await asyncio.sleep(delta)
+
+    def _make_subscriptions(self):
+        return [EventSubscription(event_type=event_name) for event_name in self._events]

--- a/remme/ws/events.py
+++ b/remme/ws/events.py
@@ -1,11 +1,9 @@
 import json
 
-import zmq
 import logging
 import weakref
 import asyncio
 
-from remme.settings import ZMQ_URL
 from concurrent.futures import TimeoutError
 from sawtooth_sdk.protobuf.client_event_pb2 import ClientEventsSubscribeRequest
 from sawtooth_sdk.protobuf.validator_pb2 import Message
@@ -13,7 +11,6 @@ from sawtooth_sdk.protobuf.events_pb2 import EventList, EventSubscription
 from google.protobuf.json_format import MessageToJson
 from sawtooth_sdk.messaging.exceptions import ValidatorConnectionError
 
-from remme.shared.utils import generate_random_key
 from remme.ws.basic import BasicWebSocketHandler
 from remme.ws.constants import Entity
 
@@ -55,7 +52,7 @@ class WSEventSocketHandler(BasicWebSocketHandler):
             content=request)
 
         try:
-            resp = future.result().content
+            resp = future.result(3).content
         except ValidatorConnectionError as vce:
             LOGGER.error('Error: %s' % vce)
             raise Exception(

--- a/remme/ws/ws.py
+++ b/remme/ws/ws.py
@@ -200,7 +200,7 @@ class WsApplicationHandler(object):
     async def _handle_subscribe(self, web_sock, payload):
         LOGGER.info('Sending initial most recent event to new subscriber')
 
-        params = payload.get('parameters', {})
+        params = payload.get('data', {})
         batch_ids = params.get('batch_ids', [])
 
         try:


### PR DESCRIPTION
Currently, after subscription, events are not received using streams.
To reproduce:
1. Subscribe
```
var webSocket = new WebSocket('ws://localhost:9080/ws/events');
webSocket.onmessage = function(data) { console.log(data); }
webSocket.send('{\"action\": \"subscribe\", \"data\": {\"entity\": \"events\"}}')
```

2. Send init request
POST /atomic-swap/init
(To get latest timestamp: https://www.unixtimestamp.com/)
```
{
  "amount": 10000,
  "created_at": 1531119695,
  "email_address_encrypted_by_initiator": "string",
  "receiver_address": "1120076d3d6ea8c2b601d0deb9273a7379697becc491e413fdb14c8e030b2bdf5ef6c7",
  "secret_lock_by_solicitor": "8bc9d977e4d5ef40f1a61fb60b687eb1924cd90ed4061f31923f36a057f54ce5",
  "sender_address_non_local": "",
  "swap_id": "033102e41346242476b15a3a7966eb5249271025fc7fb0b37ed3fdb4bcce482b"
}
```
