### PR TITLE
Update documentation for `account` and `pub_key` families

### DIFF
--- a/.env
+++ b/.env
@@ -29,7 +29,7 @@ REMME_MINIMUM_PEERS_CONNECTIVITY=1
 # Production mode
 # REMME_REST_API_AVAILABLE_METHODS=/atomic-swap:GET;/batch_status:GET;/certificate/p12:POST;/certificate:POST;/node_key:GET;/pub_key:POST;/token:GET;/transaction:POST;/user:GET
 # Dev mode
-REMME_REST_API_AVAILABLE_METHODS=/atomic-swap:GET;/batch_status:GET;/certificate/p12:POST;/certificate:POST;/node_key:GET;/pub_key:POST;/token:GET;/transaction:POST;/user:GET
+REMME_REST_API_AVAILABLE_METHODS=*
 # Path of the host folder where container exported data will be stored
 REMME_CONTAINER_EXPORTS_FOLDER=./default_export
 # Allows to disable economical features for private networks

--- a/docs/family-account.rst
+++ b/docs/family-account.rst
@@ -18,8 +18,9 @@ The following protocol buffers definition defines account entries:
 
     // Entity storing related info to a public key
     message Account {
-         uint64 balance = 1;
-         repeated string certificates = 2;
+        uint64 balance = 1;
+        // The serial number of the last issued certificate
+        uint64 pub_key_serial_number = 2;
      }
 
     // Information on weather the genesis emission has occurred

--- a/docs/family-pub-key.rst
+++ b/docs/family-pub-key.rst
@@ -35,6 +35,15 @@ The address of an entity on the storage is built as follows (where ``pubkey_pem`
     address = hash512('pub_key')[:6] + hash512(pubkey_pem)[:64]
 
 
+There is another namespace which holds links from accounts to public keys, and it is constructed as follows (where
+``account_address`` is the address of an account which own this public key and ``pub_key_serial_number`` is the
+number of the public key):
+
+.. code-block:: python
+
+    address = hash512('account_pub_key_mapping')[:6] + hash512(account_address + str(pub_key_serial_number))[:64]
+
+
 Transaction Payload
 ===================
 
@@ -80,7 +89,7 @@ Inputs and Outputs
 
 The inputs and outputs for Pub Key family transactions in respect to payload must include:
 
-* **NewPubKeyPayload**: Sender's account address, *public_key address*
+* **NewPubKeyPayload**: Sender's account address, *public_key address*, *mapping address*
 * **RevokePubKeyPayload**: *public_key address*
 
 Dependencies


### PR DESCRIPTION
Brings actual documentation about `account` and `pub_key` families changes made in [#62](https://github.com/Remmeauth/remme-core/pull/62)