### PR TITLE
Atomic-swap: refactor state fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ keys/
 docs/generated
 docs/README.rst
 docs/html/
+remme/protos
 !remme/protos/__init__.py
 docker-compose/default_export

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,5 @@ keys/
 docs/generated
 docs/README.rst
 docs/html/
-remme/protos
 !remme/protos/__init__.py
 docker-compose/default_export

--- a/remme/rest_api/atomic_swap.py
+++ b/remme/rest_api/atomic_swap.py
@@ -36,6 +36,7 @@ def set_secret_lock(**data):
     return client.swap_set_secret_lock(payload)
 
 
+@handle_key_not_found
 def close(**data):
     data = data['payload']
     swap_info = client.swap_get(data['swap_id'])

--- a/remme/rest_api/openapi.yml
+++ b/remme/rest_api/openapi.yml
@@ -646,13 +646,14 @@ responses:
         error:
           type: string
           description: Error description
+
   SwapInfo:
     description: Swap info fields
     schema:
       properties:
         state:
           description: The current state the swap is in.
-          type: integer
+          type: string
         sender_address:
           $ref: '#/definitions/Address'
         receiver_address:

--- a/remme/rest_api/openapi.yml
+++ b/remme/rest_api/openapi.yml
@@ -650,15 +650,9 @@ responses:
     description: Swap info fields
     schema:
       properties:
-        is_closed:
-          description: is swap close
-          type: boolean
-        is_expired:
-          description: is swap expired
-          type: boolean
-        is_approved:
-          description: Receiver address
-          type: boolean
+        state:
+          description: The current state the swap is in.
+          type: integer
         sender_address:
           $ref: '#/definitions/Address'
         receiver_address:

--- a/remme/tp/atomic_swap.py
+++ b/remme/tp/atomic_swap.py
@@ -76,7 +76,8 @@ class AtomicSwapHandler(BasicHandler):
         swap_info = get_data(context, AtomicSwapInfo, self.make_address_from_data(swap_id))
         if to_raise_exception and not swap_info:
             raise InvalidTransaction('Atomic swap was not initiated for {} swap id!'.format(swap_id))
-        if swap_info and swap_info.is_closed:
+
+        if swap_info and swap_info.state in [AtomicSwapInfo.CLOSED, AtomicSwapInfo.EXPIRED]:
             raise InvalidTransaction('No operations can be done upon the swap: {} '
                                      ' as it is already closed.'.format(swap_id))
         return swap_info
@@ -100,8 +101,7 @@ class AtomicSwapHandler(BasicHandler):
 
         swap_info = AtomicSwapInfo()
         swap_info.swap_id = swap_init_payload.swap_id
-        swap_info.is_closed = False
-        swap_info.is_expired = False
+        swap_info.state = AtomicSwapInfo.OPENED
         swap_info.amount = swap_init_payload.amount
         swap_info.created_at = swap_init_payload.created_at
         swap_info.email_address_encrypted_optional = swap_init_payload.email_address_encrypted_by_initiator
@@ -125,8 +125,6 @@ class AtomicSwapHandler(BasicHandler):
         LOGGER.info("2. Check weather the sender is Alice")
         # 2. Check weather the sender is Alice:
         swap_info.is_initiator = not swap_init_payload.secret_lock_by_solicitor
-        # if Bob
-        swap_info.is_approved = not swap_info.is_initiator
         # END
 
         # 3. Transfer funds to zero address.
@@ -164,10 +162,10 @@ class AtomicSwapHandler(BasicHandler):
         if not swap_info.secret_lock:
             raise InvalidTransaction('Secret Lock is needed for Bob to provide a secret key.')
 
-        if swap_info.is_closed:
+        if swap_info.state != AtomicSwapInfo.SECRET_LOCK_PROVIDED:
             raise InvalidTransaction('Swap id {} is already closed.'.format(swap_info.swap_id))
 
-        swap_info.is_approved = True
+        swap_info.state = AtomicSwapInfo.APPROVED
 
         return self.get_state_update(swap_info)
 
@@ -190,8 +188,7 @@ class AtomicSwapHandler(BasicHandler):
             raise InvalidTransaction('Swap {} needs to wait {} hours since timestamp: {} to withdraw.'.format(
                                         intiator_name, INTIATOR_TIME_LOCK, swap_info.created_at))
 
-        swap_info.is_closed = True
-        swap_info.is_expired = True
+        swap_info.state = AtomicSwapInfo.EXPIRED
 
         transfer_payload = AccountClient.get_transfer_payload(swap_info.sender_address, swap_info.amount)
         token_updated_state = AccountHandler._transfer_from_address(context,
@@ -213,6 +210,7 @@ class AtomicSwapHandler(BasicHandler):
             raise InvalidTransaction('Secret lock is already added for {}.'.format(swap_info.swap_id))
 
         swap_info.secret_lock = swap_set_lock_payload.secret_lock
+        swap_info.state = AtomicSwapInfo.SECRET_LOCK_PROVIDED
 
         return self.get_state_update(swap_info)
 
@@ -231,14 +229,13 @@ class AtomicSwapHandler(BasicHandler):
         if web3_hash(swap_close_payload.secret_key) != swap_info.secret_lock:
             raise InvalidTransaction('Secret key doesn\'t match specified secret lock!')
 
-        if not swap_info.is_approved:
+        if swap_info.is_initiator and swap_info.state != AtomicSwapInfo.APPROVED:
             raise InvalidTransaction('Transaction cannot be closed before it\'s approved.')
 
         transfer_payload = AccountClient.get_transfer_payload(swap_info.receiver_address, swap_info.amount)
         token_updated_state = AccountHandler._transfer_from_address(context,
                                                                     ZERO_ADDRESS,
                                                                     transfer_payload)
-
-        swap_info.is_closed = True
+        swap_info.state = AtomicSwapInfo.CLOSED
 
         return {**self.get_state_update(swap_info), **token_updated_state}


### PR DESCRIPTION
Implements issue REM-434.

Refactor Atomic Swaps to use the following states:

```
enum State {
  EMPTY = 0;
  OPENED = 1;
  SECRET_LOCK_PROVIDED = 2;
  APPROVED = 3;
  CLOSED = 4;
  EXPIRED = 5;
}
```
NOTE: Enums are assigned as strings in protobuf objects, not INTEGERs

Changes introduced in this pull request:

- TP
- Tests
- Rest API 
