### PR TITLE
Create custom build script for the latest Sawtooth version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,3 +76,6 @@ test:
 
 release:
 	$(BUILD_DIR)/release.sh
+
+clean_chain_data:
+	docker volume rm remme_chain_data

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,10 @@ RUN_SCRIPT=./scripts/run.sh
 BUILD_DIR=./build
 
 build:
-	$(BUILD_DIR)/build.sh
+	$(BUILD_DIR)/build.sh -r
 
 build_dev:
-	$(BUILD_DIR)/build-dev.sh
+	$(BUILD_DIR)/build.sh
 
 clean:
 	$(BUILD_DIR)/clean.sh

--- a/build/build-dev.sh
+++ b/build/build-dev.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-git submodule update --init
-docker-compose -f ./build/docker-compose.yml build

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
 
+COMPOSE_FILES="-f ./build/docker-compose.yml"
+
+while getopts ":r" opt; do
+    case $opt in
+        r)
+            echo "Running build in the release mode. This build do not use cache so it may take longer."
+            COMPOSE_FILES="$COMPOSE_FILES -f ./build/docker-compose-release.yml"
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            exit
+            ;;
+      esac
+done
+
+echo "Updating git submodules..."
 git submodule update --init
+
+echo "Running REMME build..."
 docker-compose -f ./build/docker-compose.yml -f ./build/docker-compose-release.yml build

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -15,26 +15,11 @@
 version: '3.4'
 
 services:
-  validator:
+  sawtooth:
     build:
       context: ..
       dockerfile: docker/sawtooth.dockerfile
-      target: validator
-    image: remme/sawtooth-validator:latest
-
-  block-info-tp:
-    build:
-      context: ..
-      dockerfile: docker/sawtooth.dockerfile
-      target: sawtooth-block-info-tp
-    image: remme/sawtooth-block-info-tp:latest
-
-  poet-validator-registry:
-    build:
-      context: ..
-      dockerfile: docker/sawtooth.dockerfile
-      target: validator-registry
-    image: remme/sawtooth-poet-validator-registry:latest
+    image: remme/sawtooth:latest
 
   remme-build:
     build:

--- a/config/remme-genesis-config.toml
+++ b/config/remme-genesis-config.toml
@@ -1,5 +1,4 @@
 [remme.genesis]
 token_supply = 1000000000000
 economy_enabled = true
-# leave empty for devmode
-consensus = "poet-simulator"
+consensus = "devmode"

--- a/docker/compose/base.yml
+++ b/docker/compose/base.yml
@@ -91,7 +91,7 @@ services:
     environment:
       - REMME_CONTAINER_EXPORTS_FOLDER=./default_export
     volumes:
-      - user_keys:/etc/sawtooth/keys
+      - validator_keys:/etc/sawtooth/keys
       - ${REMME_CONTAINER_EXPORTS_FOLDER:-./default_export}:/root/usr/share
       - ../../config/remme-client-config.toml:/config/remme-client-config.toml
       - ../../config/remme-rpc-api.toml:/config/remme-rpc-api.toml
@@ -100,7 +100,6 @@ services:
     entrypoint: python3 -m remme.rpc_api
 
 volumes:
-  user_keys:
   validator_keys:
   chain_data:
   logs:

--- a/docker/compose/base.yml
+++ b/docker/compose/base.yml
@@ -18,7 +18,7 @@ version: '3.4'
 services:
   validator:
     container_name: remme_validator
-    image: remme/sawtooth-validator:latest
+    image: remme/sawtooth:latest
     volumes:
       - validator_keys:/etc/sawtooth/keys
       - chain_data:/var/lib/sawtooth/
@@ -37,9 +37,15 @@ services:
       - REMME_START_MODE=run
     entrypoint: sh /scripts/validator.sh
 
+  consensus-devmode:
+    container_name: remme_consensus_devmode
+    image: remme/sawtooth:latest
+    network_mode: "service:validator"
+    entrypoint: devmode-rust -vv --connect tcp://127.0.0.1:5005
+
   validator-rest-api:
     container_name: remme_validator_rest_api
-    image: hyperledger/sawtooth-rest-api:1.0.5
+    image: remme/sawtooth:latest
     network_mode: "service:validator"
     volumes:
       - ../../config/log/validator-rest-api.toml:/etc/sawtooth/log_config.toml
@@ -48,7 +54,7 @@ services:
 
   block-info-tp:
     container_name: remme_block_info_tp
-    image: remme/sawtooth-block-info-tp:latest
+    image: remme/sawtooth:latest
     network_mode: "service:validator"
     volumes:
       - ../../config/log/block-info-tp.toml:/etc/sawtooth/log_config.toml
@@ -57,22 +63,12 @@ services:
 
   settings-tp:
     container_name: remme_settings_tp
-    image: hyperledger/sawtooth-settings-tp:1.0.5
+    image: remme/sawtooth:latest
     network_mode: "service:validator"
     entrypoint: settings-tp -vv -C tcp://127.0.0.1:4004
     volumes:
       - ../../config/log/settings-tp.toml:/etc/sawtooth/log_config.toml
       - logs:/var/log/sawtooth
-
-  poet-validator-registry:
-    container_name: remme_poet_validator_registry
-    image: remme/sawtooth-poet-validator-registry:latest
-    network_mode: "service:validator"
-    volumes:
-      - ../../config/remme-genesis-config.toml:/config/remme-genesis-config.toml
-      - ../../config/log/poet-validator-registry.toml:/etc/sawtooth/log_config.toml
-      - logs:/var/log/sawtooth
-    entrypoint: sh /scripts/poet-validator-registry.sh
 
   remme-tp:
     container_name: remme_tp

--- a/docker/compose/bg.yml
+++ b/docker/compose/bg.yml
@@ -19,7 +19,11 @@ services:
   validator:
     logging:
       driver: none
-  
+
+  consensus-devmode:
+    logging:
+      driver: none
+
   validator-rest-api:
     logging:
       driver: none

--- a/docker/compose/genesis.yml
+++ b/docker/compose/genesis.yml
@@ -21,7 +21,7 @@ services:
       - remme-genesis
     volumes:
       - genesis_data:/genesis/batch
-      - user_keys:/etc/sawtooth/keys
+      - validator_keys:/etc/sawtooth/keys
     environment:
       - REMME_START_MODE=genesis
 
@@ -29,7 +29,7 @@ services:
     container_name: remme_genesis
     image: remme/remme-core:latest
     volumes:
-      - user_keys:/etc/sawtooth/keys
+      - validator_keys:/etc/sawtooth/keys
       - genesis_data:/genesis/batch
       - ../../config/remme-client-config.toml:/config/remme-client-config.toml
       - ../../config/remme-genesis-config.toml:/config/remme-genesis-config.toml

--- a/docker/sawtooth.dockerfile
+++ b/docker/sawtooth.dockerfile
@@ -1,14 +1,17 @@
-FROM hyperledger/sawtooth-validator:1.0.5 as validator
-COPY ./scripts/node /scripts
-RUN chmod +x /scripts/toml-to-env.py
-
-FROM hyperledger/sawtooth-poet-validator-registry-tp:1.0.5 as validator-registry
-COPY ./scripts/node /scripts
-RUN chmod +x /scripts/toml-to-env.py
-
-FROM hyperledger/sawtooth-block-info-tp:1.0.4 as sawtooth-block-info-tp
+FROM ubuntu:xenial
+# TODO Change repo to bumper/stable when available
 RUN apt-get update && \
-    apt-get install patch
-WORKDIR /
+    apt-get install -y software-properties-common patch && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA && \
+    add-apt-repository 'deb http://repo.sawtooth.me/ubuntu/bumper/nightly xenial universe' && \
+    apt-get update && \
+    apt-get install -y python3-sawtooth-block-info \
+        python3-sawtooth-cli \
+        python3-sawtooth-rest-api \
+        python3-sawtooth-settings \
+        python3-sawtooth-validator \
+        sawtooth-devmode-rust
+COPY ./scripts/node /scripts
+RUN chmod +x /scripts/toml-to-env.py
 COPY ./blockinfo_fix.patch /blockinfo_fix.patch
 RUN patch -p0 < /blockinfo_fix.patch

--- a/docker/sawtooth.dockerfile
+++ b/docker/sawtooth.dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:xenial
 RUN apt-get update && \
     apt-get install -y software-properties-common patch && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA && \
-    add-apt-repository 'deb http://repo.sawtooth.me/ubuntu/bumper/nightly xenial universe' && \
+    add-apt-repository 'deb http://repo.sawtooth.me/ubuntu/nightly xenial universe' && \
     apt-get update && \
     apt-get install -y python3-sawtooth-block-info \
         python3-sawtooth-cli \

--- a/docs/family-atomic-swap.rst
+++ b/docs/family-atomic-swap.rst
@@ -109,12 +109,14 @@ Inputs and Outputs
     * **Swap address** - 70 characters concatenation of 6 chars atomic swap family prefix + 64 chars hash of the swap id.
     * **ZERO_ADDRESS** - reserved address used for locking funds *on chain*.
     * **SETTINGS_SWAP_COMMISSION** - *settings* address for retrieving operation commision amount
+    * **CONFIG_ADDRESS** - address for retrieving block configuration info
+    * **BLOCK_INFO_NAMESPACE** - namespace for retrieving any block info (in this case the latest one from block config)
 
 The inputs and outputs for account family transactions in respect to their payloads refer to following addresses:
 
-* **InitPayload**: Swap address, signer's and funds receiver's account addresses, ZERO_ADDRESS, SETTINGS_SWAP_COMMISSION
+* **InitPayload**: Swap address, signer's and funds receiver's account addresses, ZERO_ADDRESS, SETTINGS_SWAP_COMMISSION, CONFIG_ADDRESS (only input), BLOCK_INFO_NAMESPACE (only input)
 * **AtomicSwapApprovePayload**: Swap address
-* **AtomicSwapExpirePayload**: Swap address, ZERO_ADDRESS, signer's account address
+* **AtomicSwapExpirePayload**: Swap address, ZERO_ADDRESS, signer's account address, CONFIG_ADDRESS (only input), BLOCK_INFO_NAMESPACE (only input)
 * **AtomicSwapSetSecretLockPayload**: Swap address
 * **AtomicSwapClosePayload**: Swap address, ZERO_ADDRESS, receiver's account address
 

--- a/remme/clients/atomic_swap.py
+++ b/remme/clients/atomic_swap.py
@@ -22,6 +22,7 @@ from sawtooth_sdk.protobuf.setting_pb2 import Setting
 from remme.settings import SETTINGS_SWAP_COMMISSION, ZERO_ADDRESS, SETTINGS_PUB_KEY_ENCRYPTION
 from remme.settings.helper import _make_settings_key
 from remme.clients.basic import BasicClient
+from remme.clients.block_info import BLOCK_INFO_NAMESPACE, CONFIG_ADDRESS
 
 LOGGER = logging.getLogger(__name__)
 
@@ -80,7 +81,9 @@ class AtomicSwapClient(BasicClient):
             self.make_address_from_data(swap_init_payload.swap_id),
             self.get_user_address(),
             _make_settings_key(SETTINGS_SWAP_COMMISSION),
-            ZERO_ADDRESS
+            ZERO_ADDRESS,
+            CONFIG_ADDRESS,
+            BLOCK_INFO_NAMESPACE,
         ]
         addresses_output = [
             self.make_address_from_data(swap_init_payload.swap_id),
@@ -107,8 +110,13 @@ class AtomicSwapClient(BasicClient):
         addresses_input = [
             self.make_address_from_data(swap_expire_payload.swap_id),
             self.get_user_address(),
+            CONFIG_ADDRESS,
+            BLOCK_INFO_NAMESPACE,
         ]
-        addresses_output = addresses_input
+        addresses_output = [
+            self.make_address_from_data(swap_expire_payload.swap_id),
+            self.get_user_address(),
+        ]
         return self._send_transaction(AtomicSwapMethod.EXPIRE, swap_expire_payload,
                                       addresses_input, addresses_output)
 

--- a/remme/clients/basic.py
+++ b/remme/clients/basic.py
@@ -186,9 +186,10 @@ class BasicClient(Router):
         payload.method = method
         payload.data = data_pb.SerializeToString()
 
-        for address in addresses_input_output:
-            if not is_address(address):
-                raise ClientException('one of addresses_input_output {} is not an address'.format(addresses_input_output))
+        # NOTE: Not all addresses could be in the same format
+        # for address in addresses_input_output:
+        #     if not is_address(address):
+        #         raise ClientException('one of addresses_input_output {} is not an address'.format(addresses_input_output))
 
         batch_list = self.make_batch_list(payload, addresses_input, addresses_output)
 

--- a/remme/rpc_api/atomic_swap.py
+++ b/remme/rpc_api/atomic_swap.py
@@ -7,17 +7,29 @@ from aiohttp_json_rpc import (
 )
 from google.protobuf.json_format import MessageToJson
 
-from remme.clients.atomic_swap import AtomicSwapClient
+from remme.clients.atomic_swap import AtomicSwapClient, get_swap_init_payload
 from remme.shared.exceptions import KeyNotFound
 
 
 __all__ = (
     'get_atomic_swap_info',
     'get_atomic_swap_public_key',
+    # TODO: Comment (remove) this before release
+    # 'swap_init',
 )
 
 
 LOGGER = logging.getLogger(__name__)
+
+
+async def swap_init(request):
+    client = AtomicSwapClient()
+    try:
+        payload = request.params['payload']
+    except KeyError as e:
+        raise RpcInvalidParamsError(message='Missed payload')
+    payload = get_swap_init_payload(**payload)
+    return client.swap_init(payload)
 
 
 async def get_atomic_swap_info(request):

--- a/remme/rpc_api/transaction.py
+++ b/remme/rpc_api/transaction.py
@@ -32,7 +32,7 @@ from remme.clients.pub_key import PubKeyClient
 
 __all__ = (
     'send_raw_transaction',
-    # 'send_tokens',
+    'send_tokens',
     'get_batch_status',
 
     'list_receipts',

--- a/remme/tp/atomic_swap.py
+++ b/remme/tp/atomic_swap.py
@@ -25,15 +25,21 @@ from remme.protos.atomic_swap_pb2 import (
 from remme.settings import SETTINGS_SWAP_COMMISSION, ZERO_ADDRESS
 from remme.settings.helper import _get_setting_value
 
-from remme.tp.basic import BasicHandler, get_data, add_event, PROCESSOR, PB_CLASS
+from remme.tp.basic import (
+    BasicHandler,
+    get_data,
+    PROCESSOR,
+    PB_CLASS,
+)
 from remme.shared.utils import web3_hash
 
 from remme.clients.account import AccountClient
+from remme.clients.block_info import BlockInfoClient, CONFIG_ADDRESS
 from remme.tp.account import AccountHandler, get_account_by_address
+from remme.protos.block_info_pb2 import BlockInfo, BlockInfoConfig
 
 from remme.ws.basic import EMIT_EVENT
 from remme.ws.constants import Events
-
 
 
 LOGGER = logging.getLogger(__name__)
@@ -86,20 +92,44 @@ class AtomicSwapHandler(BasicHandler):
         }
 
     def get_swap_info_from_swap_id(self, context, swap_id, to_raise_exception=True):
-        swap_info = get_data(context, AtomicSwapInfo, self.make_address_from_data(swap_id))
+        swap_info = get_data(context, AtomicSwapInfo,
+                             self.make_address_from_data(swap_id))
         if to_raise_exception and not swap_info:
-            raise InvalidTransaction('Atomic swap was not initiated for {} swap id!'.format(swap_id))
+            raise InvalidTransaction(f'Atomic swap was not initiated '
+                                     f'for {swap_id} swap id!')
 
-        if swap_info and swap_info.state in [AtomicSwapInfo.CLOSED, AtomicSwapInfo.EXPIRED]:
-            raise InvalidTransaction('No operations can be done upon the swap: {} '
-                                     ' as it is already closed.'.format(swap_id))
+        if swap_info and swap_info.state in [
+            AtomicSwapInfo.CLOSED, AtomicSwapInfo.EXPIRED
+        ]:
+            raise InvalidTransaction('No operations can be done upon '
+                                     f'the swap: {swap_id} '
+                                     ' as it is already closed.')
         return swap_info
 
     def get_state_update(self, swap_info):
         return {self.make_address_from_data(swap_info.swap_id): swap_info}
 
-    def get_datetime_from_timestamp(self, timestamp):
+    @staticmethod
+    def get_datetime_from_timestamp(timestamp):
         return datetime.datetime.fromtimestamp(timestamp)
+
+    def _get_latest_block_info(self, context):
+        bc = get_data(context, BlockInfoConfig, CONFIG_ADDRESS)
+        if not bc:
+            raise InvalidTransaction('Block config not found')
+
+        LOGGER.info(f'Current latest block number: {bc.latest_block + 1}')
+
+        block = get_data(context, BlockInfo,
+                         BlockInfoClient.create_block_address(bc.latest_block))
+        if not block:
+            raise InvalidTransaction(f'Block "{bc.latest_block + 1}" '
+                                     f'not found')
+
+        LOGGER.info(f'Block with number successfully loaded: '
+                    f'{block.block_num + 1}')
+
+        return block
 
     def _swap_init(self, context, signer_pubkey, swap_init_payload):
         """
@@ -108,8 +138,10 @@ class AtomicSwapHandler(BasicHandler):
         """
         LOGGER.info("0. Check if swap ID already exists")
         # 0. Check if swap ID already exists
-        if self.get_swap_info_from_swap_id(context, swap_init_payload.swap_id, to_raise_exception=False):
-            raise InvalidTransaction('Atomic swap ID has already been taken, please use a different one!')
+        if self.get_swap_info_from_swap_id(context, swap_init_payload.swap_id,
+                                           to_raise_exception=False):
+            raise InvalidTransaction('Atomic swap ID has already been taken, '
+                                     'please use a different one!')
         # END
 
         swap_info = AtomicSwapInfo()
@@ -117,9 +149,12 @@ class AtomicSwapHandler(BasicHandler):
         swap_info.state = AtomicSwapInfo.OPENED
         swap_info.amount = swap_init_payload.amount
         swap_info.created_at = swap_init_payload.created_at
-        swap_info.email_address_encrypted_optional = swap_init_payload.email_address_encrypted_by_initiator
-        swap_info.sender_address = AccountHandler().make_address_from_data(signer_pubkey)
-        swap_info.sender_address_non_local = swap_init_payload.sender_address_non_local
+        swap_info.email_address_encrypted_optional = \
+            swap_init_payload.email_address_encrypted_by_initiator
+        swap_info.sender_address = AccountHandler() \
+            .make_address_from_data(signer_pubkey)
+        swap_info.sender_address_non_local = \
+            swap_init_payload.sender_address_non_local
         swap_info.receiver_address = swap_init_payload.receiver_address
 
         if not AccountHandler().is_handler_address(swap_info.receiver_address):
@@ -129,10 +164,13 @@ class AtomicSwapHandler(BasicHandler):
         # 1. Ensure transaction initiated within an hour
         swap_info.secret_lock = swap_init_payload.secret_lock_by_solicitor
         created_at = self.get_datetime_from_timestamp(swap_info.created_at)
-        now = datetime.datetime.utcnow()
 
-        if not (now - datetime.timedelta(hours=1) < created_at < now):
-            raise InvalidTransaction('Transaction is created a long time ago or timestamp is assigned set.')
+        block = self._get_latest_block_info(context)
+        block_time = self.get_datetime_from_timestamp(block.timestamp)
+
+        if not (block_time - datetime.timedelta(hours=1) < created_at < block_time):
+            raise InvalidTransaction('Transaction is created a long time ago '
+                                     'or timestamp is assigned set.')
         # END
 
         LOGGER.info("2. Check weather the sender is Alice")
@@ -145,20 +183,23 @@ class AtomicSwapHandler(BasicHandler):
         commission = int(_get_setting_value(context, SETTINGS_SWAP_COMMISSION))
         if commission < 0:
             raise InvalidTransaction('Wrong commission address.')
-        LOGGER.info("4. Get sender's account {}".format(swap_info.sender_address))
+        LOGGER.info(f"4. Get sender's account {swap_info.sender_address}")
         account = get_account_by_address(context, swap_info.sender_address)
         total_amount = swap_info.amount + commission
         if account.balance < total_amount:
-            raise InvalidTransaction('Not enough balance to perform the transaction in '
-                                     'the amount (with a commission) {}.'.format(total_amount))
+            raise InvalidTransaction(f'Not enough balance to perform '
+                                     f'the transaction in '
+                                     f'the amount (with a commission) '
+                                     f'{total_amount}.')
 
-        transfer_payload = AccountClient.get_transfer_payload(ZERO_ADDRESS, total_amount)
-        token_updated_state = AccountHandler()._transfer_from_address(context,
-                                                                      swap_info.sender_address,
-                                                                      transfer_payload)
+        transfer_payload = AccountClient \
+            .get_transfer_payload(ZERO_ADDRESS, total_amount)
+        token_updated_state = AccountHandler() \
+            ._transfer_from_address(context, swap_info.sender_address,
+                                    transfer_payload)
         LOGGER.info("Save state")
 
-        return {**self.get_state_update(swap_info),  **token_updated_state}
+        return {**self.get_state_update(swap_info), **token_updated_state}
 
     def _swap_approve(self, context, signer_pubkey, swap_approve_payload):
         """
@@ -169,14 +210,19 @@ class AtomicSwapHandler(BasicHandler):
         LOGGER.info('swap id: {}'.format(swap_approve_payload.swap_id))
         swap_info = self.get_swap_info_from_swap_id(context, swap_approve_payload.swap_id)
 
-        if not swap_info.is_initiator or swap_info.sender_address != AccountHandler().make_address_from_data(signer_pubkey):
-            raise InvalidTransaction('Only transaction initiator (Alice) may approve the swap, '
+        if not swap_info.is_initiator or \
+           swap_info.sender_address != AccountHandler() \
+           .make_address_from_data(signer_pubkey):
+            raise InvalidTransaction('Only transaction initiator (Alice) '
+                                     'may approve the swap, '
                                      'once Bob provided a secret lock.')
         if not swap_info.secret_lock:
-            raise InvalidTransaction('Secret Lock is needed for Bob to provide a secret key.')
+            raise InvalidTransaction('Secret Lock is needed for Bob '
+                                     'to provide a secret key.')
 
         if swap_info.state != AtomicSwapInfo.SECRET_LOCK_PROVIDED:
-            raise InvalidTransaction('Swap id {} is already closed.'.format(swap_info.swap_id))
+            raise InvalidTransaction(f'Swap id {swap_info.swap_id} '
+                                     'is already closed.')
 
         swap_info.state = AtomicSwapInfo.APPROVED
 
@@ -190,23 +236,31 @@ class AtomicSwapHandler(BasicHandler):
 
         swap_info = self.get_swap_info_from_swap_id(context, swap_expire_payload.swap_id)
 
-        if AccountHandler().make_address_from_data(signer_pubkey) != swap_info.sender_address:
-            raise InvalidTransaction('Signer is not the one who opened the swap.')
+        if AccountHandler() \
+           .make_address_from_data(signer_pubkey) != swap_info.sender_address:
+            raise InvalidTransaction('Signer is not the one who opened '
+                                     'the swap.')
 
-        now = datetime.datetime.utcnow()
+        block = self._get_latest_block_info(context)
+        block_time = self.get_datetime_from_timestamp(block.timestamp)
+
         created_at = self.get_datetime_from_timestamp(swap_info.created_at)
-        time_delta = INITIATOR_TIME_DELTA_LOCK if swap_info.is_initiator else NON_INITIATOR_TIME_DELTA_LOCK
-        if (created_at + time_delta) > now:
-            intiator_name = "initiator" if swap_info.is_initiator else "non initiator"
-            raise InvalidTransaction('Swap {} needs to wait {} hours since timestamp: {} to withdraw.'.format(
-                                        intiator_name, INTIATOR_TIME_LOCK, swap_info.created_at))
+        time_delta = INITIATOR_TIME_DELTA_LOCK \
+            if swap_info.is_initiator else NON_INITIATOR_TIME_DELTA_LOCK
+        if (created_at + time_delta) > block_time:
+            intiator_name = "initiator" \
+                if swap_info.is_initiator else "non initiator"
+            raise InvalidTransaction(f'Swap {intiator_name} needs to wait '
+                                     f'{INTIATOR_TIME_LOCK} hours since '
+                                     f'timestamp: {swap_info.created_at} '
+                                     f'to withdraw.')
 
         swap_info.state = AtomicSwapInfo.EXPIRED
 
-        transfer_payload = AccountClient.get_transfer_payload(swap_info.sender_address, swap_info.amount)
-        token_updated_state = AccountHandler()._transfer_from_address(context,
-                                                                      ZERO_ADDRESS,
-                                                                      transfer_payload)
+        transfer_payload = AccountClient \
+            .get_transfer_payload(swap_info.sender_address, swap_info.amount)
+        token_updated_state = AccountHandler() \
+            ._transfer_from_address(context, ZERO_ADDRESS, transfer_payload)
 
         return {**self.get_state_update(swap_info), **token_updated_state}
 
@@ -220,7 +274,8 @@ class AtomicSwapHandler(BasicHandler):
         swap_info = self.get_swap_info_from_swap_id(context, swap_set_lock_payload.swap_id)
 
         if swap_info.secret_lock:
-            raise InvalidTransaction('Secret lock is already added for {}.'.format(swap_info.swap_id))
+            raise InvalidTransaction(f'Secret lock is already added '
+                                     f'for {swap_info.swap_id}.')
 
         swap_info.secret_lock = swap_set_lock_payload.secret_lock
         swap_info.state = AtomicSwapInfo.SECRET_LOCK_PROVIDED
@@ -237,18 +292,21 @@ class AtomicSwapHandler(BasicHandler):
         swap_info = self.get_swap_info_from_swap_id(context, swap_close_payload.swap_id)
 
         if not swap_info.secret_lock:
-            raise InvalidTransaction('Secret lock is required to close the swap!')
+            raise InvalidTransaction('Secret lock is required to close '
+                                     'the swap!')
 
         if web3_hash(swap_close_payload.secret_key) != swap_info.secret_lock:
-            raise InvalidTransaction('Secret key doesn\'t match specified secret lock!')
+            raise InvalidTransaction('Secret key doesn\'t match specified '
+                                     'secret lock!')
 
         if swap_info.is_initiator and swap_info.state != AtomicSwapInfo.APPROVED:
-            raise InvalidTransaction('Transaction cannot be closed before it\'s approved.')
+            raise InvalidTransaction('Transaction cannot be closed '
+                                     'before it\'s approved.')
 
-        transfer_payload = AccountClient.get_transfer_payload(swap_info.receiver_address, swap_info.amount)
-        token_updated_state = AccountHandler()._transfer_from_address(context,
-                                                                    ZERO_ADDRESS,
-                                                                    transfer_payload)
+        transfer_payload = AccountClient \
+            .get_transfer_payload(swap_info.receiver_address, swap_info.amount)
+        token_updated_state = AccountHandler() \
+            ._transfer_from_address(context, ZERO_ADDRESS, transfer_payload)
         swap_info.secret_key = swap_close_payload.secret_key
 
         swap_info.state = AtomicSwapInfo.CLOSED

--- a/remme/tp/atomic_swap.py
+++ b/remme/tp/atomic_swap.py
@@ -168,7 +168,7 @@ class AtomicSwapHandler(BasicHandler):
         block = self._get_latest_block_info(context)
         block_time = self.get_datetime_from_timestamp(block.timestamp)
 
-        if not (block_time - datetime.timedelta(hours=1) < created_at < block_time):
+        if not (block_time - datetime.timedelta(hours=1) < created_at <= block_time):
             raise InvalidTransaction('Transaction is created a long time ago '
                                      'or timestamp is assigned set.')
         # END

--- a/scripts/node/poet-validator-registry.sh
+++ b/scripts/node/poet-validator-registry.sh
@@ -1,5 +1,0 @@
-eval `python3 /scripts/toml-to-env.py`
-
-if [ "$REMME_CONSENSUS" = "poet-simulator" ]; then
-    poet-validator-registry-tp -vv -C tcp://127.0.0.1:4004
-fi

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -8,6 +8,10 @@ RUN_LOGIO=0
 
 source ./config/network-config.env
 
+export REMME_REST_API_PORT
+export REMME_VALIDATOR_PORT
+export REMME_VALIDATOR_IP
+
 function check_op {
     if [ $OPERATION_SPECIFIED -eq 1 ]; then
         echo "Cannot specify two operations at once! You have already specified -$OPERATION"


### PR DESCRIPTION
This is an improved version of #115.

- Created a custom image for Sawtooth with all dependencies installed from the `nightly` channel;
- Completely removed `user_keys` volume for more consistency;
- Added `clean_chain_data` target which removes old blockchain database from the drive;
- Contains port of #128 fix for Atomic Swap synchronization;
- Removed PoET support.

Compared to #115:

- The simpler and faster build procedure.

Known issues:

- There can be troubles when a new node should catch up older blocks from the network. The node starts to work correctly after it has started up and a new block has arrived. Unsure if it is an issue of the consensus engine or CSDK. There is a pull request which should fix that [sawtooth-core/1921](https://github.com/hyperledger/sawtooth-core/pull/1921). This do not make a critical impact on the performance so I propose to leave it as it is and for an upgrade of the engine.

This PR unblocks:

- Development of our consensus algorithm engine;
- Development of service discovery.