### PR TITLE
F docker faster development setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ keys/
 docs/generated
 docs/README.rst
 docs/html/
+remme/protos/
 !remme/protos/__init__.py
 docker-compose/default_export
 logs/
+poetry.lock
+.pytest_cache

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ build:
 build_dev:
 	$(BUILD_DIR)/build.sh
 
+build_protobuf:
+	$(BUILD_DIR)/build-protobuf.sh
+
 clean:
 	$(BUILD_DIR)/clean.sh
 

--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,6 @@ run_genesis:
 run_genesis_bg:
 	$(RUN_SCRIPT) -g -u -b
 
-stop_genesis:
-	$(RUN_SCRIPT) -g -d
-
 run:
 	$(RUN_SCRIPT) -u
 
@@ -60,7 +57,7 @@ restart_bg:
 	make stop && make build_dev && make run_genesis_bg
 
 stop:
-	$(RUN_SCRIPT) -d
+	$(RUN_SCRIPT) -g -d
 
 docs:
 	$(BUILD_DIR)/build-docs.sh

--- a/Makefile
+++ b/Makefile
@@ -91,3 +91,6 @@ lint:
 
 lint_html:
 	pylint --output-format=json `find . -name "*.py"` | pylint-json2html -o report.html
+
+enter_testing_console:
+	docker run -v `realpath .`:/project/remme -it remme/remme-core:latest /bin/bash

--- a/build/build-protobuf.sh
+++ b/build/build-protobuf.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+protoc -I=./protos --python_out=./remme/protos ./protos/*.proto

--- a/build/test.sh
+++ b/build/test.sh
@@ -3,3 +3,4 @@
 git submodule update --init
 docker build -t remme/remme-core:latest -f ./docker/development.dockerfile .
 docker-compose -f ./tests/docker-compose.yml up --build --abort-on-container-exit
+docker-compose -f ./docker/compose/testing.yml up --abort-on-container-exit

--- a/docker/compose/development.yml
+++ b/docker/compose/development.yml
@@ -13,26 +13,15 @@
 # limitations under the License.
 # ------------------------------------------------------------------------
 
-# FIXME Circle CI doesn't support Compose format > 3.2. Upgrade when we move to Jenkins.
-version: '3.2'
+version: '3.4'
 
 services:
-  tests:
-    container_name: remme_tests
-    image: remme/remme-core:latest
-    network_mode: bridge
-    environment:
-      - TEST_BIND=tcp://127.0.0.1:4004
-    volumes:
-      - ../config/remme-client-config.toml:/config/remme-client-config.toml
-      - ./../:/project/remme
-    entrypoint: python3 -m unittest discover ./tests
-
   remme-tp:
-    container_name: remme_tests_tp
-    image: remme/remme-core:latest
-    network_mode: "service:tests"
     volumes:
-      - ../config/remme-client-config.toml:/config/remme-client-config.toml
-      - ./../:/project/remme
-    entrypoint: python3 -m remme.tp
+      - ./../../:/project/remme
+    entrypoint: sh -c "make build_protobuf && python3 -m remme.tp"
+
+  remme-rpc-api:
+    volumes:
+      - ./../../:/project/remme
+    entrypoint: sh -c "make build_protobuf && python3 -m remme.rpc_api"

--- a/docker/compose/testing.yml
+++ b/docker/compose/testing.yml
@@ -13,26 +13,14 @@
 # limitations under the License.
 # ------------------------------------------------------------------------
 
-# FIXME Circle CI doesn't support Compose format > 3.2. Upgrade when we move to Jenkins.
+# TODO: bump version to 3.4 after we move to Jenkins
+
 version: '3.2'
 
 services:
   tests:
-    container_name: remme_tests
+    container_name: remme_testing
     image: remme/remme-core:latest
-    network_mode: bridge
-    environment:
-      - TEST_BIND=tcp://127.0.0.1:4004
     volumes:
-      - ../config/remme-client-config.toml:/config/remme-client-config.toml
-      - ./../:/project/remme
-    entrypoint: python3 -m unittest discover ./tests
-
-  remme-tp:
-    container_name: remme_tests_tp
-    image: remme/remme-core:latest
-    network_mode: "service:tests"
-    volumes:
-      - ../config/remme-client-config.toml:/config/remme-client-config.toml
-      - ./../:/project/remme
-    entrypoint: python3 -m remme.tp
+      - ./../../:/project/remme
+    entrypoint: pytest testing

--- a/docker/compose/testing.yml
+++ b/docker/compose/testing.yml
@@ -23,4 +23,4 @@ services:
     image: remme/remme-core:latest
     volumes:
       - ./../../:/project/remme
-    entrypoint: pytest testing
+    entrypoint: sh -c "make build_protobuf && pytest testing"

--- a/docker/development.dockerfile
+++ b/docker/development.dockerfile
@@ -3,13 +3,9 @@ WORKDIR /project/remme
 RUN apk --update --no-cache add --force python3 libffi openssl libzmq && \
     pip3 install --upgrade pip && \
     pip3 install poetry
-RUN apk --update --no-cache add rsync pkgconf build-base autoconf automake protobuf libtool libffi-dev python3-dev zeromq-dev openssl-dev
-COPY ./pyproject.* ./
-COPY ./README.* ./
+RUN apk --update --no-cache add rsync pkgconf build-base autoconf automake \
+    protobuf libtool libffi-dev python3-dev zeromq-dev openssl-dev
+COPY ./pyproject.toml ./
+COPY ./README.rst ./
 RUN poetry config settings.virtualenvs.create false && \
     poetry install
-COPY ./remme ./remme
-COPY ./protos ./protos
-RUN protoc -I=./protos --python_out=./remme/protos ./protos/*.proto
-COPY ./tests ./tests
-COPY ./scripts/node /project/scripts

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -56,6 +56,10 @@ if [ $RUN_LOGIO -eq 1 ]; then
     COMPOSE_FILES="-f $COMPOSE_DIR/logio.yml"
 fi
 
+if [ $DEV -eq 1 ]; then
+    COMPOSE_FILES="$COMPOSE_FILES -f $COMPOSE_DIR/development.yml"
+fi
+
 ADDITIONAL_ARGS=""
 if [ $BG_MODE -eq 1 ]; then
     COMPOSE_FILES="$COMPOSE_FILES -f $COMPOSE_DIR/bg.yml"

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     volumes:
       - ../config/remme-client-config.toml:/config/remme-client-config.toml
       - ./../:/project/remme
-    entrypoint: python3 -m unittest discover ./tests
+    entrypoint: sh -c "make build_protobuf && python3 -m unittest discover ./tests"
 
   remme-tp:
     container_name: remme_tests_tp
@@ -35,4 +35,4 @@ services:
     volumes:
       - ../config/remme-client-config.toml:/config/remme-client-config.toml
       - ./../:/project/remme
-    entrypoint: python3 -m remme.tp
+    entrypoint: sh -c "make build_protobuf && python3 -m remme.tp"


### PR DESCRIPTION
Implements issue REM-843.

- Development mode Docker setup:
  - Code updates without rebuilding (dependency update still requires rebuilds)
  - Run with `DEV=1 make run_genesis` (probably make it consistent with other operations? Like `DEV=1 make build`)
- Run updated test suites (old will be removed after the complete migration)
- Removed separate `stop_genesis` target.