### PR TITLE
REM-931: create account if does not exist by address

### DIFF
--- a/remme/tp/atomic_swap.py
+++ b/remme/tp/atomic_swap.py
@@ -157,6 +157,10 @@ class AtomicSwapHandler(BasicHandler):
         swap_total_amount = swap_information.amount + commission
 
         account = get_data(context, Account, swap_information.sender_address)
+
+        if account is None:
+            account = Account()
+
         if account.balance < swap_total_amount:
             raise InvalidTransaction(
                 f'Not enough balance to perform the transaction in the amount (with a commission) {swap_total_amount}.'


### PR DESCRIPTION
### Jira references
- Ticket (task) — https://remmeio.atlassian.net/browse/REM-931

### Implemented
— Add account create with zero balance if atomic swap initiator address does not exists in state. So fixed:

```python
remme_testing |         account = get_data(context, Account, swap_information.sender_address)
remme_testing | >       if account.balance < swap_total_amount:
remme_testing | E       AttributeError: 'NoneType' object has no attribute 'balance'
```

