### PR TITLE
REM-957: create payment for others public keys storing implementation

### DIFF
--- a/docker/compose/testing.yml
+++ b/docker/compose/testing.yml
@@ -23,4 +23,5 @@ services:
     image: remme/remme-core:latest
     volumes:
       - ./../../:/project/remme
-    entrypoint: sh -c "make build_protobuf && pytest"
+    entrypoint: sh -c "pytest"
+#    entrypoint: sh -c "sleep 720"

--- a/docker/compose/testing.yml
+++ b/docker/compose/testing.yml
@@ -23,5 +23,4 @@ services:
     image: remme/remme-core:latest
     volumes:
       - ./../../:/project/remme
-    entrypoint: sh -c "pytest"
-#    entrypoint: sh -c "sleep 720"
+    entrypoint: sh -c "make build_protobuf && pytest"

--- a/remme/shared/forms/__init__.py
+++ b/remme/shared/forms/__init__.py
@@ -7,6 +7,12 @@ from .account import (
     GenesisPayloadForm,
     get_address_form,
 )
+from .pub_key import (
+    NewPublicKeyPayloadForm,
+    NewPubKeyStoreAndPayPayloadForm,
+    RevokePubKeyPayloadForm,
+)
+from .account import TransferPayloadForm, GenesisPayloadForm
 from .atomic_swap import (
     AtomicSwapInitPayloadForm,
     AtomicSwapApprovePayloadForm,

--- a/remme/shared/forms/pub_key.py
+++ b/remme/shared/forms/pub_key.py
@@ -44,14 +44,8 @@ class NewPublicKeyPayloadForm(ProtoForm):
 
 class NewPubKeyStoreAndPayPayloadForm(ProtoForm):
 
-    # pub_key_payload = fields.FieldList(fields.FormField(NewPublicKeyPayloadForm), max_entries=1000)
     owner_public_key = fields.StringField(validators=[validators.DataRequired()])
     signature_by_owner = fields.StringField(validators=[validators.DataRequired()])
-    #
-    # def validate(self):
-    #     is_valid = super().validate()
-    #
-    #     return is_valid
 
 
 class RevokePubKeyPayloadForm(ProtoForm):

--- a/remme/shared/forms/pub_key.py
+++ b/remme/shared/forms/pub_key.py
@@ -42,5 +42,17 @@ class NewPublicKeyPayloadForm(ProtoForm):
         return is_valid
 
 
+class NewPubKeyStoreAndPayPayloadForm(ProtoForm):
+
+    # pub_key_payload = fields.FieldList(fields.FormField(NewPublicKeyPayloadForm), max_entries=1000)
+    owner_public_key = fields.StringField(validators=[validators.DataRequired()])
+    signature_by_owner = fields.StringField(validators=[validators.DataRequired()])
+    #
+    # def validate(self):
+    #     is_valid = super().validate()
+    #
+    #     return is_valid
+
+
 class RevokePubKeyPayloadForm(ProtoForm):
     address = AddressField()

--- a/remme/tp/pub_key.py
+++ b/remme/tp/pub_key.py
@@ -354,10 +354,13 @@ class PubKeyHandler(BasicHandler):
         """
         new_public_key_payload = transaction_payload.pub_key_payload
 
-        owner_secp256k1_public_key = Secp256k1PublicKey.from_hex(transaction_payload.owner_public_key.decode())
+        owner_public_key_as_bytes = transaction_payload.owner_public_key
+        owner_public_key_as_hex = owner_public_key_as_bytes.hex()
+
+        owner_secp256k1_public_key = Secp256k1PublicKey.from_hex(owner_public_key_as_hex)
 
         is_owner_public_key_payload_signature_valid = Secp256k1Context().verify(
-            signature=transaction_payload.signature_by_owner.decode(),
+            signature=transaction_payload.signature_by_owner.hex(),
             message=new_public_key_payload.SerializeToString(),
             public_key=owner_secp256k1_public_key,
         )
@@ -372,7 +375,7 @@ class PubKeyHandler(BasicHandler):
         public_key = processor.get_public_key()
         public_key_to_store_address = self.make_address_from_data(public_key)
 
-        public_key_to_store_owner_address = AccountHandler().make_address_from_data(transaction_payload.owner_public_key)
+        public_key_to_store_owner_address = AccountHandler().make_address_from_data(owner_public_key_as_hex)
         payer_for_storing_address = AccountHandler().make_address_from_data(signer_pubkey)
 
         public_key_information, public_key_to_store_owner_account, payer_for_storing_account = get_multiple_data(context, [
@@ -394,7 +397,7 @@ class PubKeyHandler(BasicHandler):
             raise InvalidTransaction('The public key validity exceeds the maximum value.')
 
         public_key_information = PubKeyStorage()
-        public_key_information.owner = transaction_payload.owner_public_key
+        public_key_information.owner = owner_public_key_as_hex
         public_key_information.payload.CopyFrom(new_public_key_payload)
         public_key_information.is_revoked = False
 

--- a/remme/tp/pub_key.py
+++ b/remme/tp/pub_key.py
@@ -353,15 +353,15 @@ class PubKeyHandler(BasicHandler):
         """
         new_public_key_payload = transaction_payload.pub_key_payload
 
-        secp256k1_public_key = Secp256k1PublicKey.from_hex(transaction_payload.owner_public_key.decode())
+        owner_secp256k1_public_key = Secp256k1PublicKey.from_hex(transaction_payload.owner_public_key.decode())
 
         is_owner_public_key_payload_signature_valid = Secp256k1Context().verify(
             signature=transaction_payload.signature_by_owner.decode(),
             message=new_public_key_payload.SerializeToString(),
-            public_key=secp256k1_public_key,
+            public_key=owner_secp256k1_public_key,
         )
         if not is_owner_public_key_payload_signature_valid:
-            raise InvalidTransaction('Public key owner\'s signature is invalid!')
+            raise InvalidTransaction('Public key owner\'s signature is invalid.')
 
         conf_name = new_public_key_payload.WhichOneof('configuration')
         if not conf_name:

--- a/remme/tp/pub_key.py
+++ b/remme/tp/pub_key.py
@@ -16,19 +16,21 @@
 import logging
 import hashlib
 import abc
+from datetime import datetime, timedelta
 
 import ed25519
 import secp256k1
-from secp256k1 import lib
-
-from datetime import datetime, timedelta
-
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.serialization import load_der_public_key
 from sawtooth_sdk.processor.exceptions import InvalidTransaction
+from sawtooth_signing.secp256k1 import (
+    Secp256k1PublicKey,
+    Secp256k1Context
+)
+from secp256k1 import lib
 
 from remme.settings import ZERO_ADDRESS
 from remme.tp.basic import (
@@ -41,11 +43,16 @@ from remme.protos.account_pb2 import Account, TransferPayload
 from remme.protos.pub_key_pb2 import (
     PubKeyStorage,
     NewPubKeyPayload,
+    NewPubKeyStoreAndPayPayload,
     RevokePubKeyPayload,
     PubKeyMethod,
 )
 from remme.settings.helper import _get_setting_value
-from remme.shared.forms import NewPublicKeyPayloadForm, RevokePubKeyPayloadForm
+from remme.shared.forms import (
+    NewPublicKeyPayloadForm,
+    RevokePubKeyPayloadForm,
+    NewPubKeyStoreAndPayPayloadForm,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -197,6 +204,11 @@ class PubKeyHandler(BasicHandler):
                 PB_CLASS: RevokePubKeyPayload,
                 PROCESSOR: self._revoke_pub_key,
                 VALIDATOR: RevokePubKeyPayloadForm,
+            },
+            PubKeyMethod.STORE_AND_PAY: {
+                PB_CLASS: NewPubKeyStoreAndPayPayload,
+                PROCESSOR: self._store_public_key_for_other,
+                VALIDATOR: NewPubKeyStoreAndPayPayloadForm,
             }
         }
 
@@ -232,15 +244,19 @@ class PubKeyHandler(BasicHandler):
     def _store_pub_key(self, context, signer_pubkey, transaction_payload):
         """
         Store public key to the blockchain.
+
         Flow on client:
         1. Create private and public key (for instance, RSA).
         2. Create random data and sign it with private key to allows node verify signature,
             so ensure the address sent transaction is a real owner of public key.
         3. Send public key, signature, and other information to the node.
+
         Node does checks: if public key already exists in the blockchain, try to deserialize public key,
         try to verify signature, if validity exceeds.
+
         If transaction successfully passed checks, node charges fixed tokens price for storing
         public keys (if node economy is enabled) and link public key to the account (address).
+
         References:
             - https://docs.remme.io/remme-core/docs/family-pub-key.html
             - https://github.com/Remmeauth/remme-client-python/blob/develop/remme/remme_public_key_storage.py
@@ -264,9 +280,9 @@ class PubKeyHandler(BasicHandler):
         public_key_to_store_address = self.make_address_from_data(public_key)
         LOGGER.info('Public key address {}'.format(public_key_to_store_address))
 
-        sender_account_address = AccountHandler() \
-            .make_address_from_data(signer_pubkey)
+        sender_account_address = AccountHandler().make_address_from_data(signer_pubkey)
         LOGGER.info('Account address {}'.format(sender_account_address))
+
         data, account = get_multiple_data(context, [
             (public_key_to_store_address, PubKeyStorage),
             (sender_account_address, Account),
@@ -315,6 +331,104 @@ class PubKeyHandler(BasicHandler):
 
         if public_key_to_store_address not in account.pub_keys:
             account.pub_keys.append(public_key_to_store_address)
+
+        return state
+
+    def _store_public_key_for_other(self, context, signer_pubkey, transaction_payload):
+        """
+        Store public key for other account.
+
+        The transaction for account which want to pay for other account public keys storing.
+
+        A first account -> send payload -> A second account -> send transaction with first account's public key,
+        but sign and pay for storing on own -> Remme-core.
+
+        So Remme core charges tokens from a second account, but store a first account's public key.
+        Public key owner here is a first account.
+
+        Arguments:
+            context (sawtooth_sdk.processor.context): context to store updated state (blockchain data).
+            signer_pubkey: transaction sender public key.
+            transaction_payload (pub_key_pb2.NewPubKeyStoreAndPayPayload): payload for storing public key for other.
+        """
+        new_public_key_payload = transaction_payload.pub_key_payload
+
+        secp256k1_public_key = Secp256k1PublicKey.from_hex(transaction_payload.owner_public_key.decode())
+
+        is_owner_public_key_payload_signature_valid = Secp256k1Context().verify(
+            signature=transaction_payload.signature_by_owner.decode(),
+            message=new_public_key_payload.SerializeToString(),
+            public_key=secp256k1_public_key,
+        )
+        if not is_owner_public_key_payload_signature_valid:
+            raise InvalidTransaction('Public key owner\'s signature is invalid!')
+
+        conf_name = new_public_key_payload.WhichOneof('configuration')
+        if not conf_name:
+            raise InvalidTransaction('Configuration for public key not set')
+
+        conf_payload = getattr(new_public_key_payload, conf_name)
+
+        processor_cls = detect_processor_cls(conf_payload)
+        processor = processor_cls(new_public_key_payload.entity_hash,
+                                  new_public_key_payload.entity_hash_signature,
+                                  new_public_key_payload.valid_from,
+                                  new_public_key_payload.valid_to,
+                                  new_public_key_payload.hashing_algorithm,
+                                  conf_payload)
+
+        sig_is_valid = processor.verify()
+        if sig_is_valid is False:
+            raise InvalidTransaction('Payed public key has invalid signature.')
+
+        public_key = processor.get_public_key()
+        public_key_to_store_address = self.make_address_from_data(public_key)
+
+        public_key_to_store_owner_address = AccountHandler().make_address_from_data(transaction_payload.owner_public_key)
+        payer_for_storing_address = AccountHandler().make_address_from_data(signer_pubkey)
+
+        public_key_information, public_key_to_store_owner_account, payer_for_storing_account = get_multiple_data(context, [
+            (public_key_to_store_address, PubKeyStorage),
+            (public_key_to_store_owner_address, Account),
+            (payer_for_storing_address, Account),
+        ])
+
+        if public_key_information:
+            raise InvalidTransaction('This public key is already registered.')
+
+        if payer_for_storing_account is None:
+            payer_for_storing_account = Account()
+
+        if not self._is_public_key_validity_exceeded(
+            valid_from=new_public_key_payload.valid_from,
+            valid_to=new_public_key_payload.valid_to,
+        ):
+            raise InvalidTransaction('The public key validity exceeds the maximum value.')
+
+        public_key_information = PubKeyStorage()
+        public_key_information.owner = transaction_payload.owner_public_key
+        public_key_information.payload.CopyFrom(new_public_key_payload)
+        public_key_information.is_revoked = False
+
+        state = {
+            public_key_to_store_owner_address: public_key_to_store_owner_account,
+            payer_for_storing_address: payer_for_storing_account,
+            public_key_to_store_address: public_key_information,
+        }
+
+        is_economy_enabled = _get_setting_value(context, 'remme.economy_enabled', 'true').lower()
+        if is_economy_enabled == 'true':
+
+            if ZERO_ADDRESS != payer_for_storing_address:
+
+                transfer_state = self._charge_tokens_for_storing(
+                    context=context, address_from=payer_for_storing_address, address_to=ZERO_ADDRESS,
+                )
+
+                state.update(transfer_state)
+
+        if public_key_to_store_address not in public_key_to_store_owner_account.pub_keys:
+            public_key_to_store_owner_account.pub_keys.append(public_key_to_store_address)
 
         return state
 

--- a/testing/unit/tp/public_key/base.py
+++ b/testing/unit/tp/public_key/base.py
@@ -121,9 +121,9 @@ def generate_ecdsa_payload(key=None, entity_hash=None, entity_hash_signature=Non
     )
 
 
-def generate_header(payload, inputs, outputs):
+def generate_header(payload, inputs, outputs, signer_public_key=None):
     return TransactionHeader(
-        signer_public_key=SENDER_PUBLIC_KEY,
+        signer_public_key=SENDER_PUBLIC_KEY if signer_public_key is None else signer_public_key,
         family_name=TRANSACTION_REQUEST_ACCOUNT_HANDLER_PARAMS.get('family_name'),
         family_version=TRANSACTION_REQUEST_ACCOUNT_HANDLER_PARAMS.get('family_version'),
         inputs=inputs,

--- a/testing/unit/tp/public_key/base.py
+++ b/testing/unit/tp/public_key/base.py
@@ -121,9 +121,9 @@ def generate_ecdsa_payload(key=None, entity_hash=None, entity_hash_signature=Non
     )
 
 
-def generate_header(payload, inputs, outputs, signer_public_key=None):
+def generate_header(payload, inputs, outputs, signer_public_key=SENDER_PUBLIC_KEY):
     return TransactionHeader(
-        signer_public_key=SENDER_PUBLIC_KEY if signer_public_key is None else signer_public_key,
+        signer_public_key=signer_public_key,
         family_name=TRANSACTION_REQUEST_ACCOUNT_HANDLER_PARAMS.get('family_name'),
         family_version=TRANSACTION_REQUEST_ACCOUNT_HANDLER_PARAMS.get('family_version'),
         inputs=inputs,

--- a/testing/unit/tp/public_key/test_store_for_other.py
+++ b/testing/unit/tp/public_key/test_store_for_other.py
@@ -67,44 +67,53 @@ INPUTS = OUTPUTS = [
 ]
 
 
-def test_store_rsa_public_key_for_other_with_empty_proto():
-    """
-    Case: send transaction request to store certificate public key with empty protobuf.
-    Expect: invalid transaction error with detailed description about missed protobuf parameters.
-    """
-    new_public_key_store_and_pay_payload = NewPubKeyStoreAndPayPayload()
-
-    transaction_payload = TransactionPayload()
-    transaction_payload.method = PubKeyMethod.STORE_AND_PAY
-    transaction_payload.data = new_public_key_store_and_pay_payload.SerializeToString()
-
-    serialized_transaction_payload = transaction_payload.SerializeToString()
-
-    transaction_header = generate_header(
-        serialized_transaction_payload, INPUTS, OUTPUTS, signer_public_key=PAYER_PUBLIC_KEY,
-    )
-
-    serialized_header = transaction_header.SerializeToString()
-
-    transaction_request = TpProcessRequest(
-        header=transaction_header,
-        payload=serialized_transaction_payload,
-        signature=create_signer(private_key=PAYER_PRIVATE_KEY).sign(serialized_header),
-    )
-
-    mock_context = StubContext(inputs=INPUTS, outputs=OUTPUTS, initial_state={})
-
-    with pytest.raises(InvalidTransaction) as error:
-        PubKeyHandler().apply(transaction=transaction_request, context=mock_context)
-
-    assert proto_error_msg(
-        NewPubKeyStoreAndPayPayload,
-        {
-            'owner_public_key': ['This field is required.'],
-            'signature_by_owner': ['This field is required.'],
-            'pub_key_payload': ['This field is required.'],
-        }
-    ) == str(error.value)
+# def test_store_rsa_public_key_for_other_with_empty_proto():
+#     """
+#     Case: send transaction request to store certificate public key with empty protobuf.
+#     Expect: invalid transaction error with detailed description about missed protobuf parameters.
+#     """
+#     new_public_key_store_and_pay_payload = NewPubKeyStoreAndPayPayload()
+#
+#     transaction_payload = TransactionPayload()
+#     transaction_payload.method = PubKeyMethod.STORE_AND_PAY
+#     transaction_payload.data = new_public_key_store_and_pay_payload.SerializeToString()
+#
+#     serialized_transaction_payload = transaction_payload.SerializeToString()
+#
+#     transaction_header = generate_header(
+#         serialized_transaction_payload, INPUTS, OUTPUTS, signer_public_key=PAYER_PUBLIC_KEY,
+#     )
+#
+#     serialized_header = transaction_header.SerializeToString()
+#
+#     transaction_request = TpProcessRequest(
+#         header=transaction_header,
+#         payload=serialized_transaction_payload,
+#         signature=create_signer(private_key=PAYER_PRIVATE_KEY).sign(serialized_header),
+#     )
+#
+#     mock_context = StubContext(inputs=INPUTS, outputs=OUTPUTS, initial_state={})
+#
+#     with pytest.raises(InvalidTransaction) as error:
+#         PubKeyHandler().apply(transaction=transaction_request, context=mock_context)
+#
+#     assert proto_error_msg(
+#         NewPubKeyStoreAndPayPayload,
+#         {
+#             'pub_key_payload': {
+#                 'hashing_algorithm': ['Not a valid choice'],
+#                 'entity_hash': ['This field is required.'],
+#                 'entity_hash_signature': ['This field is required.'],
+#                 'valid_from': ['This field is required.'],
+#                 'valid_to': ['This field is required.'],
+#                 'configuration': [
+#                     'At least one of RSAConfiguration, ECDSAConfiguration or Ed25519Configuration must be set',
+#                 ],
+#             },
+#             'owner_public_key': ['This field is required.'],
+#             'signature_by_owner': ['This field is required.'],
+#         }
+#     ) == str(error.value)
 
 
 def test_store_rsa_public_key_for_other():

--- a/testing/unit/tp/public_key/test_store_for_other.py
+++ b/testing/unit/tp/public_key/test_store_for_other.py
@@ -1,0 +1,161 @@
+"""
+Provide tests for public key handler store method implementation.
+"""
+import pytest
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import rsa
+from sawtooth_sdk.processor.exceptions import InvalidTransaction
+from sawtooth_sdk.protobuf.processor_pb2 import TpProcessRequest
+from sawtooth_sdk.protobuf.setting_pb2 import Setting
+from sawtooth_signing.secp256k1 import (
+    Secp256k1PrivateKey,
+    Secp256k1Context
+)
+
+from remme.protos.account_pb2 import Account
+from remme.protos.pub_key_pb2 import (
+    PubKeyStorage,
+    PubKeyMethod,
+    NewPubKeyPayload,
+    NewPubKeyStoreAndPayPayload,
+)
+from remme.protos.transaction_pb2 import TransactionPayload
+from remme.settings import ZERO_ADDRESS
+from remme.tp.pub_key import (
+    PUB_KEY_STORE_PRICE,
+    PubKeyHandler,
+)
+from testing.conftest import (
+    create_private_key,
+    create_signer,
+)
+from testing.utils.client import (
+    generate_rsa_signature, generate_address, proto_error_msg
+)
+from testing.mocks.stub import StubContext
+from .base import (
+    CERTIFICATE_PUBLIC_KEY,
+    ADDRESS_FROM_CERTIFICATE_PUBLIC_KEY,
+    ADDRESS_FROM_ED25519_PUBLIC_KEY,
+    ADDRESS_FROM_ECDSA_PUBLIC_KEY,
+    SENDER_PUBLIC_KEY,
+    SENDER_PRIVATE_KEY,
+    SENDER_ADDRESS,
+    SENDER_INITIAL_BALANCE,
+    RANDOM_ALREADY_STORED_SENDER_PUBLIC_KEY,
+    EXCEEDED_PUBLIC_KEY_VALIDITY_TIMESTAMP,
+    IS_NODE_ECONOMY_ENABLED_ADDRESS,
+    generate_header,
+    generate_rsa_payload,
+    generate_ed25519_payload,
+    generate_ecdsa_payload,
+)
+
+
+OWNER_PRIVATE_KEY = 'baea35704ff361475ede4f6fee4a542e2e74eaaf07c38e1d1931e07de5e6487f'
+OWNER_PUBLIC_KEY = '022a20772a806cf32393663055ae8ad26e60ee2619ae449fe7b6ebe0f355006c4e'
+OWNER_ADDRESS = '11200781ae7b6618d6eae1fba104f3ed5565fab462a6f735b3e2a3978d5d5c1fe81579'
+
+PAYER_PRIVATE_KEY = '8c87d914a6cfeaf027413760ad359b5a56bfe0eda504d879b21872c7dc5b911c'
+PAYER_PUBLIC_KEY = '02feb988591c78e58e57cdce5a314bd04798971227fcc2316907355392a2c99c25'
+PAYER_ADDRESS = '112007db8a00c010402e2e3a7d03491323e761e0ea612481c518605648ceeb5ed454f7'
+PAYER_INITIAL_BALANCE = 5000
+
+INPUTS = OUTPUTS = [
+    ADDRESS_FROM_CERTIFICATE_PUBLIC_KEY,
+    OWNER_ADDRESS,
+    PAYER_ADDRESS,
+    ZERO_ADDRESS,
+    IS_NODE_ECONOMY_ENABLED_ADDRESS,
+]
+
+
+def test_public_key_handler_rsa_store():
+    """
+    Case:
+    Expect:
+    """
+    new_public_key_payload = generate_rsa_payload(key=CERTIFICATE_PUBLIC_KEY)
+    serialized_new_public_key_payload = new_public_key_payload.SerializeToString()
+
+    private_key = Secp256k1PrivateKey.from_hex(OWNER_PRIVATE_KEY)
+    signature = Secp256k1Context().sign(serialized_new_public_key_payload, private_key)
+
+    new_public_key_store_and_pay_payload = NewPubKeyStoreAndPayPayload(
+        pub_key_payload=new_public_key_payload,
+        owner_public_key=OWNER_PUBLIC_KEY.encode(),
+        signature_by_owner=signature.encode(),
+    )
+
+    transaction_payload = TransactionPayload()
+    transaction_payload.method = PubKeyMethod.STORE_AND_PAY
+    transaction_payload.data = new_public_key_store_and_pay_payload.SerializeToString()
+
+    serialized_transaction_payload = transaction_payload.SerializeToString()
+
+    transaction_header = generate_header(
+        serialized_transaction_payload, INPUTS, OUTPUTS, signer_public_key=PAYER_PUBLIC_KEY,
+    )
+
+    serialized_header = transaction_header.SerializeToString()
+
+    transaction_request = TpProcessRequest(
+        header=transaction_header,
+        payload=serialized_transaction_payload,
+        signature=create_signer(private_key=PAYER_PRIVATE_KEY).sign(serialized_header),
+    )
+
+    payer_account = Account()
+    payer_account.balance = PAYER_INITIAL_BALANCE
+    serialized_payer_account = payer_account.SerializeToString()
+
+    owner_account = Account()
+    owner_account.pub_keys.append(RANDOM_ALREADY_STORED_SENDER_PUBLIC_KEY)
+    owner_account.pub_keys.append(ADDRESS_FROM_CERTIFICATE_PUBLIC_KEY)
+    serialized_owner_account = owner_account.SerializeToString()
+
+    zero_account = Account()
+    zero_account.balance = 0
+    serialized_zero_account = zero_account.SerializeToString()
+
+    mock_context = StubContext(inputs=INPUTS, outputs=OUTPUTS, initial_state={
+        OWNER_ADDRESS: serialized_owner_account,
+        PAYER_ADDRESS: serialized_payer_account,
+        ZERO_ADDRESS: serialized_zero_account,
+    })
+
+    expected_public_key_storage = PubKeyStorage()
+    expected_public_key_storage.owner = OWNER_ADDRESS
+    expected_public_key_storage.payload.CopyFrom(new_public_key_payload)
+    expected_public_key_storage.is_revoked = False
+    expected_serialized_public_key_storage = expected_public_key_storage.SerializeToString()
+
+    expected_payer_account = Account()
+    expected_payer_account.balance = PAYER_INITIAL_BALANCE - PUB_KEY_STORE_PRICE
+    serialized_expected_payer_account = expected_payer_account.SerializeToString()
+
+    expected_owner_account = Account()
+    expected_owner_account.pub_keys.append(RANDOM_ALREADY_STORED_SENDER_PUBLIC_KEY)
+    expected_owner_account.pub_keys.append(ADDRESS_FROM_CERTIFICATE_PUBLIC_KEY)
+    serialized_expected_owner_account = expected_owner_account.SerializeToString()
+
+    expected_zero_account = Account()
+    expected_zero_account.balance = 0 + PUB_KEY_STORE_PRICE
+    expected_serialized_zero_account = expected_zero_account.SerializeToString()
+
+    expected_state = {
+        OWNER_ADDRESS: serialized_expected_owner_account,
+        PAYER_ADDRESS: serialized_expected_payer_account,
+        ADDRESS_FROM_CERTIFICATE_PUBLIC_KEY: expected_serialized_public_key_storage,
+        ZERO_ADDRESS: expected_serialized_zero_account,
+    }
+
+    PubKeyHandler().apply(transaction=transaction_request, context=mock_context)
+
+    state_as_list = mock_context.get_state(addresses=[
+        OWNER_ADDRESS, PAYER_ADDRESS, ADDRESS_FROM_CERTIFICATE_PUBLIC_KEY, ZERO_ADDRESS,
+    ])
+
+    state_as_dict = {entry.address: entry.data for entry in state_as_list}
+
+    assert expected_state == state_as_dict

--- a/testing/unit/tp/public_key/test_store_for_other.py
+++ b/testing/unit/tp/public_key/test_store_for_other.py
@@ -25,24 +25,20 @@ from remme.tp.pub_key import (
     PUB_KEY_STORE_PRICE,
     PubKeyHandler,
 )
-from testing.conftest import (
-    create_private_key,
-    create_signer,
-)
+from testing.conftest import create_signer
 from testing.utils.client import (
-    generate_rsa_signature, generate_address, proto_error_msg
+    generate_address,
+    generate_rsa_signature,
+    proto_error_msg,
 )
 from testing.mocks.stub import StubContext
 from .base import (
-    CERTIFICATE_PUBLIC_KEY,
     ADDRESS_FROM_CERTIFICATE_PUBLIC_KEY,
+    CERTIFICATE_PUBLIC_KEY,
+    ED25519_PUBLIC_KEY,
     ADDRESS_FROM_ED25519_PUBLIC_KEY,
+    ECDSA_PUBLIC_KEY,
     ADDRESS_FROM_ECDSA_PUBLIC_KEY,
-    SENDER_PUBLIC_KEY,
-    SENDER_PRIVATE_KEY,
-    SENDER_ADDRESS,
-    SENDER_INITIAL_BALANCE,
-    RANDOM_ALREADY_STORED_SENDER_PUBLIC_KEY,
     EXCEEDED_PUBLIC_KEY_VALIDITY_TIMESTAMP,
     IS_NODE_ECONOMY_ENABLED_ADDRESS,
     generate_header,
@@ -51,15 +47,16 @@ from .base import (
     generate_ecdsa_payload,
 )
 
-
 OWNER_PRIVATE_KEY = 'baea35704ff361475ede4f6fee4a542e2e74eaaf07c38e1d1931e07de5e6487f'
 OWNER_PUBLIC_KEY = '022a20772a806cf32393663055ae8ad26e60ee2619ae449fe7b6ebe0f355006c4e'
 OWNER_ADDRESS = '11200781ae7b6618d6eae1fba104f3ed5565fab462a6f735b3e2a3978d5d5c1fe81579'
 
-PAYER_PRIVATE_KEY = '8c87d914a6cfeaf027413760ad359b5a56bfe0eda504d879b21872c7dc5b911c'
-PAYER_PUBLIC_KEY = '02feb988591c78e58e57cdce5a314bd04798971227fcc2316907355392a2c99c25'
-PAYER_ADDRESS = '112007db8a00c010402e2e3a7d03491323e761e0ea612481c518605648ceeb5ed454f7'
+PAYER_PRIVATE_KEY = 'bdf1567f8f3374d128d32466eb9862ecb0f2f23930abd6ee94990f418780e889'
+PAYER_PUBLIC_KEY = '0360f28da594661d39deabf2817cad2bdacdcca043e91004d3c935fa9e93caa1a3'
+PAYER_ADDRESS = '1120078c9ac38f8b9c6c0560afd71ade8b7821cc5a43486320578f9fa8414ee975af88'
 PAYER_INITIAL_BALANCE = 5000
+
+RANDOM_ALREADY_STORED_OWNER_PUBLIC_KEY_ADDRESS = 'a23be17ca9c3bd150627ac6469f11ccf25c0c96d8bb8ac333879d3ea06a90413cd4536'
 
 INPUTS = OUTPUTS = [
     ADDRESS_FROM_CERTIFICATE_PUBLIC_KEY,
@@ -70,21 +67,61 @@ INPUTS = OUTPUTS = [
 ]
 
 
-def test_public_key_handler_rsa_store():
+def test_store_rsa_public_key_for_other_with_empty_proto():
     """
-    Case:
-    Expect:
+    Case: send transaction request to store certificate public key with empty protobuf.
+    Expect: invalid transaction error with detailed description about missed protobuf parameters.
+    """
+    new_public_key_store_and_pay_payload = NewPubKeyStoreAndPayPayload()
+
+    transaction_payload = TransactionPayload()
+    transaction_payload.method = PubKeyMethod.STORE_AND_PAY
+    transaction_payload.data = new_public_key_store_and_pay_payload.SerializeToString()
+
+    serialized_transaction_payload = transaction_payload.SerializeToString()
+
+    transaction_header = generate_header(
+        serialized_transaction_payload, INPUTS, OUTPUTS, signer_public_key=PAYER_PUBLIC_KEY,
+    )
+
+    serialized_header = transaction_header.SerializeToString()
+
+    transaction_request = TpProcessRequest(
+        header=transaction_header,
+        payload=serialized_transaction_payload,
+        signature=create_signer(private_key=PAYER_PRIVATE_KEY).sign(serialized_header),
+    )
+
+    mock_context = StubContext(inputs=INPUTS, outputs=OUTPUTS, initial_state={})
+
+    with pytest.raises(InvalidTransaction) as error:
+        PubKeyHandler().apply(transaction=transaction_request, context=mock_context)
+
+    assert proto_error_msg(
+        NewPubKeyStoreAndPayPayload,
+        {
+            'owner_public_key': ['This field is required.'],
+            'signature_by_owner': ['This field is required.'],
+            'pub_key_payload': ['This field is required.'],
+        }
+    ) == str(error.value)
+
+
+def test_store_rsa_public_key_for_other():
+    """
+    Case: send transaction request to store certificate public key (RSA) for other.
+    Expect: public key information is stored to blockchain linked to owner address. Transaction sender paid for storing.
     """
     new_public_key_payload = generate_rsa_payload(key=CERTIFICATE_PUBLIC_KEY)
     serialized_new_public_key_payload = new_public_key_payload.SerializeToString()
 
     private_key = Secp256k1PrivateKey.from_hex(OWNER_PRIVATE_KEY)
-    signature = Secp256k1Context().sign(serialized_new_public_key_payload, private_key)
+    signature_by_owner = Secp256k1Context().sign(serialized_new_public_key_payload, private_key)
 
     new_public_key_store_and_pay_payload = NewPubKeyStoreAndPayPayload(
         pub_key_payload=new_public_key_payload,
         owner_public_key=OWNER_PUBLIC_KEY.encode(),
-        signature_by_owner=signature.encode(),
+        signature_by_owner=signature_by_owner.encode(),
     )
 
     transaction_payload = TransactionPayload()
@@ -110,8 +147,7 @@ def test_public_key_handler_rsa_store():
     serialized_payer_account = payer_account.SerializeToString()
 
     owner_account = Account()
-    owner_account.pub_keys.append(RANDOM_ALREADY_STORED_SENDER_PUBLIC_KEY)
-    owner_account.pub_keys.append(ADDRESS_FROM_CERTIFICATE_PUBLIC_KEY)
+    owner_account.pub_keys.append(RANDOM_ALREADY_STORED_OWNER_PUBLIC_KEY_ADDRESS)
     serialized_owner_account = owner_account.SerializeToString()
 
     zero_account = Account()
@@ -125,7 +161,7 @@ def test_public_key_handler_rsa_store():
     })
 
     expected_public_key_storage = PubKeyStorage()
-    expected_public_key_storage.owner = OWNER_ADDRESS
+    expected_public_key_storage.owner = OWNER_PUBLIC_KEY
     expected_public_key_storage.payload.CopyFrom(new_public_key_payload)
     expected_public_key_storage.is_revoked = False
     expected_serialized_public_key_storage = expected_public_key_storage.SerializeToString()
@@ -135,12 +171,607 @@ def test_public_key_handler_rsa_store():
     serialized_expected_payer_account = expected_payer_account.SerializeToString()
 
     expected_owner_account = Account()
-    expected_owner_account.pub_keys.append(RANDOM_ALREADY_STORED_SENDER_PUBLIC_KEY)
+    expected_owner_account.pub_keys.append(RANDOM_ALREADY_STORED_OWNER_PUBLIC_KEY_ADDRESS)
     expected_owner_account.pub_keys.append(ADDRESS_FROM_CERTIFICATE_PUBLIC_KEY)
     serialized_expected_owner_account = expected_owner_account.SerializeToString()
 
     expected_zero_account = Account()
     expected_zero_account.balance = 0 + PUB_KEY_STORE_PRICE
+    expected_serialized_zero_account = expected_zero_account.SerializeToString()
+
+    expected_state = {
+        OWNER_ADDRESS: serialized_expected_owner_account,
+        PAYER_ADDRESS: serialized_expected_payer_account,
+        ADDRESS_FROM_CERTIFICATE_PUBLIC_KEY: expected_serialized_public_key_storage,
+        ZERO_ADDRESS: expected_serialized_zero_account,
+    }
+
+    PubKeyHandler().apply(transaction=transaction_request, context=mock_context)
+
+    state_as_list = mock_context.get_state(addresses=[
+        OWNER_ADDRESS, PAYER_ADDRESS, ADDRESS_FROM_CERTIFICATE_PUBLIC_KEY, ZERO_ADDRESS,
+    ])
+
+    state_as_dict = {entry.address: entry.data for entry in state_as_list}
+
+    assert expected_state == state_as_dict
+
+
+def test_store_ed25519_public_key():
+    """
+    Case: send transaction request to store certificate public key (Ed25519) for other.
+    Expect: public key information is stored to blockchain linked to owner address. Transaction sender paid for storing.
+    """
+    inputs = outputs = [
+        ADDRESS_FROM_ED25519_PUBLIC_KEY,
+        OWNER_ADDRESS,
+        PAYER_ADDRESS,
+        ZERO_ADDRESS,
+        IS_NODE_ECONOMY_ENABLED_ADDRESS,
+    ]
+
+    new_public_key_payload = generate_ed25519_payload(key=ED25519_PUBLIC_KEY)
+    serialized_new_public_key_payload = new_public_key_payload.SerializeToString()
+
+    private_key = Secp256k1PrivateKey.from_hex(OWNER_PRIVATE_KEY)
+    signature_by_owner = Secp256k1Context().sign(serialized_new_public_key_payload, private_key)
+
+    new_public_key_store_and_pay_payload = NewPubKeyStoreAndPayPayload(
+        pub_key_payload=new_public_key_payload,
+        owner_public_key=OWNER_PUBLIC_KEY.encode(),
+        signature_by_owner=signature_by_owner.encode(),
+    )
+
+    transaction_payload = TransactionPayload()
+    transaction_payload.method = PubKeyMethod.STORE_AND_PAY
+    transaction_payload.data = new_public_key_store_and_pay_payload.SerializeToString()
+
+    serialized_transaction_payload = transaction_payload.SerializeToString()
+
+    transaction_header = generate_header(
+        serialized_transaction_payload, INPUTS, OUTPUTS, signer_public_key=PAYER_PUBLIC_KEY,
+    )
+
+    serialized_header = transaction_header.SerializeToString()
+
+    transaction_request = TpProcessRequest(
+        header=transaction_header,
+        payload=serialized_transaction_payload,
+        signature=create_signer(private_key=PAYER_PRIVATE_KEY).sign(serialized_header),
+    )
+
+    payer_account = Account()
+    payer_account.balance = PAYER_INITIAL_BALANCE
+    serialized_payer_account = payer_account.SerializeToString()
+
+    owner_account = Account()
+    owner_account.pub_keys.append(RANDOM_ALREADY_STORED_OWNER_PUBLIC_KEY_ADDRESS)
+    serialized_owner_account = owner_account.SerializeToString()
+
+    zero_account = Account()
+    zero_account.balance = 0
+    serialized_zero_account = zero_account.SerializeToString()
+
+    mock_context = StubContext(inputs=inputs, outputs=outputs, initial_state={
+        OWNER_ADDRESS: serialized_owner_account,
+        PAYER_ADDRESS: serialized_payer_account,
+        ZERO_ADDRESS: serialized_zero_account,
+    })
+
+    expected_public_key_storage = PubKeyStorage()
+    expected_public_key_storage.owner = OWNER_PUBLIC_KEY
+    expected_public_key_storage.payload.CopyFrom(new_public_key_payload)
+    expected_public_key_storage.is_revoked = False
+    expected_serialized_public_key_storage = expected_public_key_storage.SerializeToString()
+
+    expected_payer_account = Account()
+    expected_payer_account.balance = PAYER_INITIAL_BALANCE - PUB_KEY_STORE_PRICE
+    serialized_expected_payer_account = expected_payer_account.SerializeToString()
+
+    expected_owner_account = Account()
+    expected_owner_account.pub_keys.append(RANDOM_ALREADY_STORED_OWNER_PUBLIC_KEY_ADDRESS)
+    expected_owner_account.pub_keys.append(ADDRESS_FROM_ED25519_PUBLIC_KEY)
+    serialized_expected_owner_account = expected_owner_account.SerializeToString()
+
+    expected_zero_account = Account()
+    expected_zero_account.balance = 0 + PUB_KEY_STORE_PRICE
+    expected_serialized_zero_account = expected_zero_account.SerializeToString()
+
+    expected_state = {
+        OWNER_ADDRESS: serialized_expected_owner_account,
+        PAYER_ADDRESS: serialized_expected_payer_account,
+        ADDRESS_FROM_ED25519_PUBLIC_KEY: expected_serialized_public_key_storage,
+        ZERO_ADDRESS: expected_serialized_zero_account,
+    }
+
+    PubKeyHandler().apply(transaction=transaction_request, context=mock_context)
+
+    state_as_list = mock_context.get_state(addresses=[
+        OWNER_ADDRESS, PAYER_ADDRESS, ADDRESS_FROM_ED25519_PUBLIC_KEY, ZERO_ADDRESS,
+    ])
+
+    state_as_dict = {entry.address: entry.data for entry in state_as_list}
+
+    assert expected_state == state_as_dict
+
+
+def test_store_ecdsa_public_key():
+    """
+    Case: send transaction request to store certificate public key (ECDSA) for other.
+    Expect: public key information is stored to blockchain linked to owner address. Transaction sender paid for storing.
+    """
+    inputs = outputs = [
+        ADDRESS_FROM_ECDSA_PUBLIC_KEY,
+        OWNER_ADDRESS,
+        PAYER_ADDRESS,
+        ZERO_ADDRESS,
+        IS_NODE_ECONOMY_ENABLED_ADDRESS,
+    ]
+
+    new_public_key_payload = generate_ecdsa_payload(key=ECDSA_PUBLIC_KEY)
+    serialized_new_public_key_payload = new_public_key_payload.SerializeToString()
+
+    private_key = Secp256k1PrivateKey.from_hex(OWNER_PRIVATE_KEY)
+    signature_by_owner = Secp256k1Context().sign(serialized_new_public_key_payload, private_key)
+
+    new_public_key_store_and_pay_payload = NewPubKeyStoreAndPayPayload(
+        pub_key_payload=new_public_key_payload,
+        owner_public_key=OWNER_PUBLIC_KEY.encode(),
+        signature_by_owner=signature_by_owner.encode(),
+    )
+
+    transaction_payload = TransactionPayload()
+    transaction_payload.method = PubKeyMethod.STORE_AND_PAY
+    transaction_payload.data = new_public_key_store_and_pay_payload.SerializeToString()
+
+    serialized_transaction_payload = transaction_payload.SerializeToString()
+
+    transaction_header = generate_header(
+        serialized_transaction_payload, INPUTS, OUTPUTS, signer_public_key=PAYER_PUBLIC_KEY,
+    )
+
+    serialized_header = transaction_header.SerializeToString()
+
+    transaction_request = TpProcessRequest(
+        header=transaction_header,
+        payload=serialized_transaction_payload,
+        signature=create_signer(private_key=PAYER_PRIVATE_KEY).sign(serialized_header),
+    )
+
+    payer_account = Account()
+    payer_account.balance = PAYER_INITIAL_BALANCE
+    serialized_payer_account = payer_account.SerializeToString()
+
+    owner_account = Account()
+    owner_account.pub_keys.append(RANDOM_ALREADY_STORED_OWNER_PUBLIC_KEY_ADDRESS)
+    serialized_owner_account = owner_account.SerializeToString()
+
+    zero_account = Account()
+    zero_account.balance = 0
+    serialized_zero_account = zero_account.SerializeToString()
+
+    mock_context = StubContext(inputs=inputs, outputs=outputs, initial_state={
+        OWNER_ADDRESS: serialized_owner_account,
+        PAYER_ADDRESS: serialized_payer_account,
+        ZERO_ADDRESS: serialized_zero_account,
+    })
+
+    expected_public_key_storage = PubKeyStorage()
+    expected_public_key_storage.owner = OWNER_PUBLIC_KEY
+    expected_public_key_storage.payload.CopyFrom(new_public_key_payload)
+    expected_public_key_storage.is_revoked = False
+    expected_serialized_public_key_storage = expected_public_key_storage.SerializeToString()
+
+    expected_payer_account = Account()
+    expected_payer_account.balance = PAYER_INITIAL_BALANCE - PUB_KEY_STORE_PRICE
+    serialized_expected_payer_account = expected_payer_account.SerializeToString()
+
+    expected_owner_account = Account()
+    expected_owner_account.pub_keys.append(RANDOM_ALREADY_STORED_OWNER_PUBLIC_KEY_ADDRESS)
+    expected_owner_account.pub_keys.append(ADDRESS_FROM_ECDSA_PUBLIC_KEY)
+    serialized_expected_owner_account = expected_owner_account.SerializeToString()
+
+    expected_zero_account = Account()
+    expected_zero_account.balance = 0 + PUB_KEY_STORE_PRICE
+    expected_serialized_zero_account = expected_zero_account.SerializeToString()
+
+    expected_state = {
+        OWNER_ADDRESS: serialized_expected_owner_account,
+        PAYER_ADDRESS: serialized_expected_payer_account,
+        ADDRESS_FROM_ECDSA_PUBLIC_KEY: expected_serialized_public_key_storage,
+        ZERO_ADDRESS: expected_serialized_zero_account,
+    }
+
+    PubKeyHandler().apply(transaction=transaction_request, context=mock_context)
+
+    state_as_list = mock_context.get_state(addresses=[
+        OWNER_ADDRESS, PAYER_ADDRESS, ADDRESS_FROM_ECDSA_PUBLIC_KEY, ZERO_ADDRESS,
+    ])
+
+    state_as_dict = {entry.address: entry.data for entry in state_as_list}
+
+    assert expected_state == state_as_dict
+
+
+def test_store_public_key_for_other_decode_error():
+    """
+    Case: send transaction request, to store certificate public key for other, with invalid transaction payload.
+    Expect: invalid transaction error is raised with cannot decode transaction payload error message.
+    """
+    serialized_not_valid_transaction_payload = b'F1120071db7c02f5731d06df194dc95465e9b27'
+
+    transaction_header = generate_header(serialized_not_valid_transaction_payload, INPUTS, OUTPUTS)
+
+    serialized_header = transaction_header.SerializeToString()
+
+    transaction_request = TpProcessRequest(
+        header=transaction_header,
+        payload=serialized_not_valid_transaction_payload,
+        signature=create_signer(private_key=PAYER_PRIVATE_KEY).sign(serialized_header),
+    )
+
+    mock_context = StubContext(inputs=INPUTS, outputs=OUTPUTS, initial_state={})
+
+    with pytest.raises(InvalidTransaction) as error:
+        PubKeyHandler().apply(transaction=transaction_request, context=mock_context)
+
+    assert 'Cannot decode transaction payload.' == str(error.value)
+
+
+def test_store_public_key_for_other_invalid_transfer_method():
+    """
+    Case: send transaction request, to store certificate public key for other, with invalid transfer method value.
+    Expect: invalid transaction error is raised with invalid account method value error message.
+    """
+    account_method_impossible_value = 5347
+
+    new_public_key_payload = generate_rsa_payload()
+
+    transaction_payload = TransactionPayload()
+    transaction_payload.method = account_method_impossible_value
+    transaction_payload.data = new_public_key_payload.SerializeToString()
+
+    serialized_transaction_payload = transaction_payload.SerializeToString()
+
+    transaction_header = generate_header(serialized_transaction_payload, INPUTS, OUTPUTS)
+
+    serialized_header = transaction_header.SerializeToString()
+
+    transaction_request = TpProcessRequest(
+        header=transaction_header,
+        payload=serialized_transaction_payload,
+        signature=create_signer(private_key=PAYER_PRIVATE_KEY).sign(serialized_header),
+    )
+
+    mock_context = StubContext(inputs=INPUTS, outputs=OUTPUTS, initial_state={})
+
+    with pytest.raises(InvalidTransaction) as error:
+        PubKeyHandler().apply(transaction=transaction_request, context=mock_context)
+
+    assert f'Invalid account method value ({account_method_impossible_value}) has been set.' == str(error.value)
+
+
+def test_store_public_key_for_other_bad_owner_signature():
+    """
+    Case: send transaction request to store certificate public key for other with bad owner signature.
+    Expect: invalid transaction error is raised with public key owner's signature is invalid error message.
+    """
+    new_public_key_payload = generate_rsa_payload(key=CERTIFICATE_PUBLIC_KEY)
+
+    bad_owner_signature = b'8376g487h9doinjcht8978032iub9yc89u023[owds'
+
+    new_public_key_store_and_pay_payload = NewPubKeyStoreAndPayPayload(
+        pub_key_payload=new_public_key_payload,
+        owner_public_key=OWNER_PUBLIC_KEY.encode(),
+        signature_by_owner=bad_owner_signature,
+    )
+
+    transaction_payload = TransactionPayload()
+    transaction_payload.method = PubKeyMethod.STORE_AND_PAY
+    transaction_payload.data = new_public_key_store_and_pay_payload.SerializeToString()
+
+    serialized_transaction_payload = transaction_payload.SerializeToString()
+
+    transaction_header = generate_header(
+        serialized_transaction_payload, INPUTS, OUTPUTS, signer_public_key=PAYER_PUBLIC_KEY,
+    )
+
+    serialized_header = transaction_header.SerializeToString()
+
+    transaction_request = TpProcessRequest(
+        header=transaction_header,
+        payload=serialized_transaction_payload,
+        signature=create_signer(private_key=PAYER_PRIVATE_KEY).sign(serialized_header),
+    )
+
+    already_registered_public_key = PubKeyStorage()
+    already_registered_public_key.owner = OWNER_PUBLIC_KEY
+    already_registered_public_key.payload.CopyFrom(new_public_key_payload)
+    already_registered_public_key.is_revoked = False
+    serialized_already_registered_public_key = already_registered_public_key.SerializeToString()
+
+    mock_context = StubContext(inputs=INPUTS, outputs=OUTPUTS, initial_state={
+        ADDRESS_FROM_CERTIFICATE_PUBLIC_KEY: serialized_already_registered_public_key,
+    })
+
+    with pytest.raises(InvalidTransaction) as error:
+        PubKeyHandler().apply(transaction=transaction_request, context=mock_context)
+
+    assert 'Public key owner\'s signature is invalid.' == str(error.value)
+
+
+def test_store_public_key_for_other_already_registered_public_key():
+    """
+    Case: send transaction request to store already registered certificate public key for other.
+    Expect: invalid transaction error is raised with public key is already registered error message.
+    """
+    new_public_key_payload = generate_rsa_payload(key=CERTIFICATE_PUBLIC_KEY)
+    serialized_new_public_key_payload = new_public_key_payload.SerializeToString()
+
+    private_key = Secp256k1PrivateKey.from_hex(OWNER_PRIVATE_KEY)
+    signature_by_owner = Secp256k1Context().sign(serialized_new_public_key_payload, private_key)
+
+    new_public_key_store_and_pay_payload = NewPubKeyStoreAndPayPayload(
+        pub_key_payload=new_public_key_payload,
+        owner_public_key=OWNER_PUBLIC_KEY.encode(),
+        signature_by_owner=signature_by_owner.encode(),
+    )
+
+    transaction_payload = TransactionPayload()
+    transaction_payload.method = PubKeyMethod.STORE_AND_PAY
+    transaction_payload.data = new_public_key_store_and_pay_payload.SerializeToString()
+
+    serialized_transaction_payload = transaction_payload.SerializeToString()
+
+    transaction_header = generate_header(
+        serialized_transaction_payload, INPUTS, OUTPUTS, signer_public_key=PAYER_PUBLIC_KEY,
+    )
+
+    serialized_header = transaction_header.SerializeToString()
+
+    transaction_request = TpProcessRequest(
+        header=transaction_header,
+        payload=serialized_transaction_payload,
+        signature=create_signer(private_key=PAYER_PRIVATE_KEY).sign(serialized_header),
+    )
+
+    already_registered_public_key = PubKeyStorage()
+    already_registered_public_key.owner = OWNER_PUBLIC_KEY
+    already_registered_public_key.payload.CopyFrom(new_public_key_payload)
+    already_registered_public_key.is_revoked = False
+    serialized_already_registered_public_key = already_registered_public_key.SerializeToString()
+
+    mock_context = StubContext(inputs=INPUTS, outputs=OUTPUTS, initial_state={
+        ADDRESS_FROM_CERTIFICATE_PUBLIC_KEY: serialized_already_registered_public_key,
+    })
+
+    with pytest.raises(InvalidTransaction) as error:
+        PubKeyHandler().apply(transaction=transaction_request, context=mock_context)
+
+    assert 'This public key is already registered.' == str(error.value)
+
+
+def test_store_public_key_for_other_not_der_public_key_format():
+    """
+    Case: send transaction request to store certificate public key not in DER format for other.
+    Expect: invalid transaction error is raised with public key is already registered error message.
+    """
+    not_der_format_public_key_to_store = b'h8ybuhtvrofpckejfhgubicojslmkghvbiuokl'
+
+    address_from_public_key_to_store = generate_address('pub_key', not_der_format_public_key_to_store)
+
+    inputs = outputs = [
+        address_from_public_key_to_store,
+        OWNER_ADDRESS,
+        ZERO_ADDRESS,
+        IS_NODE_ECONOMY_ENABLED_ADDRESS,
+    ]
+
+    new_public_key_payload = generate_rsa_payload(key=not_der_format_public_key_to_store)
+    serialized_new_public_key_payload = new_public_key_payload.SerializeToString()
+
+    private_key = Secp256k1PrivateKey.from_hex(OWNER_PRIVATE_KEY)
+    signature_by_owner = Secp256k1Context().sign(serialized_new_public_key_payload, private_key)
+
+    new_public_key_store_and_pay_payload = NewPubKeyStoreAndPayPayload(
+        pub_key_payload=new_public_key_payload,
+        owner_public_key=OWNER_PUBLIC_KEY.encode(),
+        signature_by_owner=signature_by_owner.encode(),
+    )
+
+    transaction_payload = TransactionPayload()
+    transaction_payload.method = PubKeyMethod.STORE_AND_PAY
+    transaction_payload.data = new_public_key_store_and_pay_payload.SerializeToString()
+
+    serialized_transaction_payload = transaction_payload.SerializeToString()
+
+    transaction_header = generate_header(
+        serialized_transaction_payload, inputs, outputs, signer_public_key=PAYER_PUBLIC_KEY,
+    )
+
+    serialized_header = transaction_header.SerializeToString()
+
+    transaction_request = TpProcessRequest(
+        header=transaction_header,
+        payload=serialized_transaction_payload,
+        signature=create_signer(private_key=PAYER_PRIVATE_KEY).sign(serialized_header),
+    )
+
+    mock_context = StubContext(inputs=inputs, outputs=outputs, initial_state={})
+
+    with pytest.raises(InvalidTransaction) as error:
+        PubKeyHandler().apply(transaction=transaction_request, context=mock_context)
+
+    assert 'Cannot deserialize the provided public key. Check if it is in DER format.' == str(error.value)
+
+
+def test_store_public_key_for_other_invalid_certificate_signature():
+    """
+    Case: send transaction request, to store certificate public for other, when certificate signature_by_owner is invalid.
+    Expect: invalid transaction error is raised with public key is already registered error message.
+    """
+    not_user_certificate_private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=2048, backend=default_backend(),
+    )
+
+    entity_hash_signature = generate_rsa_signature(b'w', not_user_certificate_private_key)
+
+    new_public_key_payload = generate_rsa_payload(
+        key=CERTIFICATE_PUBLIC_KEY, entity_hash_signature=entity_hash_signature,
+    )
+    serialized_new_public_key_payload = new_public_key_payload.SerializeToString()
+
+    private_key = Secp256k1PrivateKey.from_hex(OWNER_PRIVATE_KEY)
+    signature_by_owner = Secp256k1Context().sign(serialized_new_public_key_payload, private_key)
+
+    new_public_key_store_and_pay_payload = NewPubKeyStoreAndPayPayload(
+        pub_key_payload=new_public_key_payload,
+        owner_public_key=OWNER_PUBLIC_KEY.encode(),
+        signature_by_owner=signature_by_owner.encode(),
+    )
+
+    transaction_payload = TransactionPayload()
+    transaction_payload.method = PubKeyMethod.STORE_AND_PAY
+    transaction_payload.data = new_public_key_store_and_pay_payload.SerializeToString()
+    serialized_transaction_payload = transaction_payload.SerializeToString()
+
+    transaction_header = generate_header(serialized_transaction_payload, INPUTS, OUTPUTS)
+    serialized_header = transaction_header.SerializeToString()
+
+    transaction_request = TpProcessRequest(
+        header=transaction_header,
+        payload=serialized_transaction_payload,
+        signature=create_signer(private_key=PAYER_PRIVATE_KEY).sign(serialized_header),
+    )
+
+    mock_context = StubContext(inputs=INPUTS, outputs=OUTPUTS, initial_state={})
+
+    with pytest.raises(InvalidTransaction) as error:
+        PubKeyHandler().apply(transaction=transaction_request, context=mock_context)
+
+    assert 'Payed public key has invalid signature.' == str(error.value)
+
+
+def test_store_public_key_for_other_public_key_exceeded_validity():
+    """
+    Case: send transaction request to store certificate public key with exceeded validity for other.
+    Expect: invalid transaction error is raised with validity exceeds the maximum value error message.
+    """
+    new_public_key_payload = generate_rsa_payload(
+        key=CERTIFICATE_PUBLIC_KEY, valid_to=int(EXCEEDED_PUBLIC_KEY_VALIDITY_TIMESTAMP),
+    )
+    serialized_new_public_key_payload = new_public_key_payload.SerializeToString()
+
+    private_key = Secp256k1PrivateKey.from_hex(OWNER_PRIVATE_KEY)
+    signature_by_owner = Secp256k1Context().sign(serialized_new_public_key_payload, private_key)
+
+    new_public_key_store_and_pay_payload = NewPubKeyStoreAndPayPayload(
+        pub_key_payload=new_public_key_payload,
+        owner_public_key=OWNER_PUBLIC_KEY.encode(),
+        signature_by_owner=signature_by_owner.encode(),
+    )
+
+    transaction_payload = TransactionPayload()
+    transaction_payload.method = PubKeyMethod.STORE_AND_PAY
+    transaction_payload.data = new_public_key_store_and_pay_payload.SerializeToString()
+
+    serialized_transaction_payload = transaction_payload.SerializeToString()
+
+    transaction_header = generate_header(
+        serialized_transaction_payload, INPUTS, OUTPUTS, signer_public_key=PAYER_PUBLIC_KEY,
+    )
+
+    serialized_header = transaction_header.SerializeToString()
+
+    transaction_request = TpProcessRequest(
+        header=transaction_header,
+        payload=serialized_transaction_payload,
+        signature=create_signer(private_key=PAYER_PRIVATE_KEY).sign(serialized_header),
+    )
+
+    mock_context = StubContext(inputs=INPUTS, outputs=OUTPUTS, initial_state={})
+
+    with pytest.raises(InvalidTransaction) as error:
+        PubKeyHandler().apply(transaction=transaction_request, context=mock_context)
+
+    assert 'The public key validity exceeds the maximum value.' == str(error.value)
+
+
+def test_store_public_key_for_other_economy_is_not_enabled():
+    """
+    Case: send transaction request, to store certificate public key for other, when economy isn't enabled.
+    Expect: public key information is stored to blockchain linked to owner address. Owner hasn't paid for storing.
+    """
+    new_public_key_payload = generate_rsa_payload(key=CERTIFICATE_PUBLIC_KEY)
+    serialized_new_public_key_payload = new_public_key_payload.SerializeToString()
+
+    private_key = Secp256k1PrivateKey.from_hex(OWNER_PRIVATE_KEY)
+    signature_by_owner = Secp256k1Context().sign(serialized_new_public_key_payload, private_key)
+
+    new_public_key_store_and_pay_payload = NewPubKeyStoreAndPayPayload(
+        pub_key_payload=new_public_key_payload,
+        owner_public_key=OWNER_PUBLIC_KEY.encode(),
+        signature_by_owner=signature_by_owner.encode(),
+    )
+
+    transaction_payload = TransactionPayload()
+    transaction_payload.method = PubKeyMethod.STORE_AND_PAY
+    transaction_payload.data = new_public_key_store_and_pay_payload.SerializeToString()
+
+    serialized_transaction_payload = transaction_payload.SerializeToString()
+
+    transaction_header = generate_header(
+        serialized_transaction_payload, INPUTS, OUTPUTS, signer_public_key=PAYER_PUBLIC_KEY,
+    )
+
+    serialized_header = transaction_header.SerializeToString()
+
+    transaction_request = TpProcessRequest(
+        header=transaction_header,
+        payload=serialized_transaction_payload,
+        signature=create_signer(private_key=PAYER_PRIVATE_KEY).sign(serialized_header),
+    )
+
+    payer_account = Account()
+    payer_account.balance = PAYER_INITIAL_BALANCE
+    serialized_payer_account = payer_account.SerializeToString()
+
+    owner_account = Account()
+    owner_account.pub_keys.append(RANDOM_ALREADY_STORED_OWNER_PUBLIC_KEY_ADDRESS)
+    serialized_owner_account = owner_account.SerializeToString()
+
+    zero_account = Account()
+    zero_account.balance = 0
+    serialized_zero_account = zero_account.SerializeToString()
+
+    is_economy_enabled_setting = Setting()
+    is_economy_enabled_setting.entries.add(key='remme.economy_enabled', value='false')
+    serialized_is_economy_enabled_setting = is_economy_enabled_setting.SerializeToString()
+
+    mock_context = StubContext(inputs=INPUTS, outputs=OUTPUTS, initial_state={
+        OWNER_ADDRESS: serialized_owner_account,
+        PAYER_ADDRESS: serialized_payer_account,
+        ZERO_ADDRESS: serialized_zero_account,
+        IS_NODE_ECONOMY_ENABLED_ADDRESS: serialized_is_economy_enabled_setting,
+    })
+
+    expected_public_key_storage = PubKeyStorage()
+    expected_public_key_storage.owner = OWNER_PUBLIC_KEY
+    expected_public_key_storage.payload.CopyFrom(new_public_key_payload)
+    expected_public_key_storage.is_revoked = False
+    expected_serialized_public_key_storage = expected_public_key_storage.SerializeToString()
+
+    expected_payer_account = Account()
+    expected_payer_account.balance = PAYER_INITIAL_BALANCE
+    serialized_expected_payer_account = expected_payer_account.SerializeToString()
+
+    expected_owner_account = Account()
+    expected_owner_account.pub_keys.append(RANDOM_ALREADY_STORED_OWNER_PUBLIC_KEY_ADDRESS)
+    expected_owner_account.pub_keys.append(ADDRESS_FROM_CERTIFICATE_PUBLIC_KEY)
+    serialized_expected_owner_account = expected_owner_account.SerializeToString()
+
+    expected_zero_account = Account()
+    expected_zero_account.balance = 0
     expected_serialized_zero_account = expected_zero_account.SerializeToString()
 
     expected_state = {

--- a/testing/unit/tp/public_key/test_store_for_other.py
+++ b/testing/unit/tp/public_key/test_store_for_other.py
@@ -129,8 +129,8 @@ def test_store_rsa_public_key_for_other():
 
     new_public_key_store_and_pay_payload = NewPubKeyStoreAndPayPayload(
         pub_key_payload=new_public_key_payload,
-        owner_public_key=OWNER_PUBLIC_KEY.encode(),
-        signature_by_owner=signature_by_owner.encode(),
+        owner_public_key=bytes.fromhex(OWNER_PUBLIC_KEY),
+        signature_by_owner=bytes.fromhex(signature_by_owner),
     )
 
     transaction_payload = TransactionPayload()
@@ -227,8 +227,8 @@ def test_store_ed25519_public_key():
 
     new_public_key_store_and_pay_payload = NewPubKeyStoreAndPayPayload(
         pub_key_payload=new_public_key_payload,
-        owner_public_key=OWNER_PUBLIC_KEY.encode(),
-        signature_by_owner=signature_by_owner.encode(),
+        owner_public_key=bytes.fromhex(OWNER_PUBLIC_KEY),
+        signature_by_owner=bytes.fromhex(signature_by_owner),
     )
 
     transaction_payload = TransactionPayload()
@@ -325,8 +325,8 @@ def test_store_ecdsa_public_key():
 
     new_public_key_store_and_pay_payload = NewPubKeyStoreAndPayPayload(
         pub_key_payload=new_public_key_payload,
-        owner_public_key=OWNER_PUBLIC_KEY.encode(),
-        signature_by_owner=signature_by_owner.encode(),
+        owner_public_key=bytes.fromhex(OWNER_PUBLIC_KEY),
+        signature_by_owner=bytes.fromhex(signature_by_owner),
     )
 
     transaction_payload = TransactionPayload()
@@ -467,12 +467,12 @@ def test_store_public_key_for_other_bad_owner_signature():
     """
     new_public_key_payload = generate_rsa_payload(key=CERTIFICATE_PUBLIC_KEY)
 
-    bad_owner_signature = b'8376g487h9doinjcht8978032iub9yc89u023[owds'
+    bad_owner_signature = 'dd8b2dca17d4d507f77edd8b2dca17d4d507f77edd8b2dca17d4d507f77edd8b2dca17d4d507f77e'
 
     new_public_key_store_and_pay_payload = NewPubKeyStoreAndPayPayload(
         pub_key_payload=new_public_key_payload,
-        owner_public_key=OWNER_PUBLIC_KEY.encode(),
-        signature_by_owner=bad_owner_signature,
+        owner_public_key=bytes.fromhex(OWNER_PUBLIC_KEY),
+        signature_by_owner=bytes.fromhex(bad_owner_signature),
     )
 
     transaction_payload = TransactionPayload()
@@ -522,8 +522,8 @@ def test_store_public_key_for_other_already_registered_public_key():
 
     new_public_key_store_and_pay_payload = NewPubKeyStoreAndPayPayload(
         pub_key_payload=new_public_key_payload,
-        owner_public_key=OWNER_PUBLIC_KEY.encode(),
-        signature_by_owner=signature_by_owner.encode(),
+        owner_public_key=bytes.fromhex(OWNER_PUBLIC_KEY),
+        signature_by_owner=bytes.fromhex(signature_by_owner),
     )
 
     transaction_payload = TransactionPayload()
@@ -584,8 +584,8 @@ def test_store_public_key_for_other_not_der_public_key_format():
 
     new_public_key_store_and_pay_payload = NewPubKeyStoreAndPayPayload(
         pub_key_payload=new_public_key_payload,
-        owner_public_key=OWNER_PUBLIC_KEY.encode(),
-        signature_by_owner=signature_by_owner.encode(),
+        owner_public_key=bytes.fromhex(OWNER_PUBLIC_KEY),
+        signature_by_owner=bytes.fromhex(signature_by_owner),
     )
 
     transaction_payload = TransactionPayload()
@@ -635,8 +635,8 @@ def test_store_public_key_for_other_invalid_certificate_signature():
 
     new_public_key_store_and_pay_payload = NewPubKeyStoreAndPayPayload(
         pub_key_payload=new_public_key_payload,
-        owner_public_key=OWNER_PUBLIC_KEY.encode(),
-        signature_by_owner=signature_by_owner.encode(),
+        owner_public_key=bytes.fromhex(OWNER_PUBLIC_KEY),
+        signature_by_owner=bytes.fromhex(signature_by_owner),
     )
 
     transaction_payload = TransactionPayload()
@@ -676,8 +676,8 @@ def test_store_public_key_for_other_public_key_exceeded_validity():
 
     new_public_key_store_and_pay_payload = NewPubKeyStoreAndPayPayload(
         pub_key_payload=new_public_key_payload,
-        owner_public_key=OWNER_PUBLIC_KEY.encode(),
-        signature_by_owner=signature_by_owner.encode(),
+        owner_public_key=bytes.fromhex(OWNER_PUBLIC_KEY),
+        signature_by_owner=bytes.fromhex(signature_by_owner),
     )
 
     transaction_payload = TransactionPayload()
@@ -719,8 +719,8 @@ def test_store_public_key_for_other_economy_is_not_enabled():
 
     new_public_key_store_and_pay_payload = NewPubKeyStoreAndPayPayload(
         pub_key_payload=new_public_key_payload,
-        owner_public_key=OWNER_PUBLIC_KEY.encode(),
-        signature_by_owner=signature_by_owner.encode(),
+        owner_public_key=bytes.fromhex(OWNER_PUBLIC_KEY),
+        signature_by_owner=bytes.fromhex(signature_by_owner),
     )
 
     transaction_payload = TransactionPayload()


### PR DESCRIPTION
### Jira references
- Ticket (task) — https://remmeio.atlassian.net/browse/REM-957

### Description
To allow another account pay for public key for storing owner account, owner account send public key to store payload, signature and public key. Then another account send transaction for storing, pays for storing, but owner of public key is owner account.

### Implemented
— Create payment for others public keys storing implementation.
— Create tests for others public keys storing implementation.

### References
- Payment for others public keys storing implementation workflow — https://remmeio.atlassian.net/wiki/spaces/WikiREMME/pages/515539700/2019-01-09+RFC+10+Workflow+to+pay+for+others+keys+registration+variant+2