### PR TITLE
[REM-993] Fix invalid messege for method: get_atomic_swap_info, get_b…

### DIFF
--- a/remme/rpc_api/transaction.py
+++ b/remme/rpc_api/transaction.py
@@ -31,7 +31,7 @@ from remme.tp.__main__ import TP_HANDLERS
 from remme.clients.account import AccountClient
 from remme.clients.pub_key import PubKeyClient
 from remme.protos.transaction_pb2 import TransactionPayload
-from remme.shared.forms import IdentifierForm, IdentifiersForm
+from remme.shared.forms import IdentifierForm, IdentifiersForm, BatchIdentifierForm
 
 from .utils import validate_params
 
@@ -210,7 +210,7 @@ async def fetch_batch(request):
         raise KeyNotFound(f'Batch with id "{id}" not found')
 
 
-@validate_params(IdentifierForm)
+@validate_params(BatchIdentifierForm)
 async def get_batch_status(request):
     id = request.params['id']
 

--- a/remme/shared/forms/__init__.py
+++ b/remme/shared/forms/__init__.py
@@ -18,6 +18,7 @@ from .atomic_swap import (
 from .identifier import (
     IdentifierForm,
     IdentifiersForm,
+    BatchIdentifierForm,
 )
 from .personal import (
     NodePKForm,

--- a/remme/shared/forms/_fields.py
+++ b/remme/shared/forms/_fields.py
@@ -13,9 +13,7 @@ class AddressField(fields.StringField):
 class SwapIDField(fields.StringField):
 
     validators = [
-        validators.InputRequired(message='Missed swap_id'),
-        validators.Regexp('[0-9a-f]{64}',
-                          message='Incorrect atomic swap identifier.')
+        validators.Regexp('[0-9a-f]{64}', message='Given swap identifier is invalid')
     ]
 
 
@@ -25,4 +23,11 @@ class IDField(fields.StringField):
         validators.InputRequired(message='Missed id'),
         validators.Regexp('[0-9a-f]{128}',
                           message='Incorrect identifier.')
+    ]
+
+
+class BatchIdField(fields.StringField):
+
+    validators = [
+        validators.Regexp('[0-9a-f]{128}', message='Given batch identifier is invalid')
     ]

--- a/remme/shared/forms/_fields.py
+++ b/remme/shared/forms/_fields.py
@@ -4,7 +4,7 @@ from wtforms import fields, validators
 class AddressField(fields.StringField):
 
     validators = [
-        validators.DataRequired(message='Missed address'),
+        validators.InputRequired(message='Missed address'),
         validators.Regexp('[0-9a-f]{70}',
                           message='Address is not of a blockchain token type.')
     ]
@@ -13,7 +13,7 @@ class AddressField(fields.StringField):
 class SwapIDField(fields.StringField):
 
     validators = [
-        validators.DataRequired(message='Missed swap_id'),
+        validators.InputRequired(message='Missed swap_id'),
         validators.Regexp('[0-9a-f]{64}',
                           message='Incorrect atomic swap identifier.')
     ]
@@ -22,7 +22,7 @@ class SwapIDField(fields.StringField):
 class IDField(fields.StringField):
 
     validators = [
-        validators.DataRequired(message='Missed id'),
+        validators.InputRequired(message='Missed id'),
         validators.Regexp('[0-9a-f]{128}',
                           message='Incorrect identifier.')
     ]

--- a/remme/shared/forms/identifier.py
+++ b/remme/shared/forms/identifier.py
@@ -1,11 +1,15 @@
 from wtforms import fields, validators
 
 from .base import ProtoForm
-from ._fields import IDField
+from ._fields import IDField, BatchIdField
 
 
 class IdentifierForm(ProtoForm):
     id = IDField()
+
+
+class BatchIdentifierForm(ProtoForm):
+    id = BatchIdField()
 
 
 class IdentifiersForm(ProtoForm):


### PR DESCRIPTION
Implements issue REM-993.

Changes introduced in this pull request:

-  change DataRequired on InputRequired validators. DataRequired used to be called Required but the way it behaved (requiring coerced data, not input data) meant it functioned in a way which was not symmetric to the Optional validator and furthermore caused confusion with certain fields which coerced data to 'falsey' values like 0,  Decimal(0), time(0) etc. InputRequired check if field  not empty(0 is not empty in InputRequired). In this task timely error on validation parametrs = 0. This will be pass on validation were before raise error . 