### PR TITLE
REM-1138: Fix method get_balance with invalid parameter public_key_address

### DIFF
--- a/remme/rpc_api/account.py
+++ b/remme/rpc_api/account.py
@@ -14,29 +14,27 @@
 # ------------------------------------------------------------------------
 import logging
 
-from remme.shared.forms import get_address_form
 from remme.clients.account import AccountClient
-
-from .utils import validate_params
+from remme.rpc_api.utils import validate_params
+from remme.shared.forms import get_address_form
 
 __all__ = (
     'get_balance',
     'get_public_keys_list',
 )
 
-
 logger = logging.getLogger(__name__)
+
+client = AccountClient()
 
 
 @validate_params(get_address_form('public_key_address'))
 async def get_balance(request):
-    client = AccountClient()
     address = request.params['public_key_address']
     return await client.get_balance(address)
 
 
 @validate_params(get_address_form('public_key_address'))
 async def get_public_keys_list(request):
-    client = AccountClient()
     address = request.params['public_key_address']
     return await client.get_pub_keys(address)

--- a/testing/unit/rpc/test_account.py
+++ b/testing/unit/rpc/test_account.py
@@ -1,10 +1,67 @@
 import pytest
 from aiohttp_json_rpc.exceptions import RpcInvalidParamsError
 
-from remme.rpc_api.account import get_public_keys_list
+from remme.rpc_api.account import (
+    get_balance,
+    get_public_keys_list,
+)
 from testing.utils._async import return_async_value
 
 PUBLIC_KEY_ADDRESS = 'public_key_address'
+
+
+@pytest.mark.asyncio
+async def test_get_balance(mocker, request_):
+    """
+    Case: get balance.
+    Expect: list with addresses.
+    """
+    public_key_address = '112007081971dec92814033df35188ce17c740d5e58d7632c9528b61a88a4b4cde51e1'
+    expected_result = 0
+
+    mock_get_block_info = mocker.patch('remme.clients.account.AccountClient.get_balance')
+    mock_get_block_info.return_value = return_async_value(expected_result)
+
+    request_.params = {
+        PUBLIC_KEY_ADDRESS: public_key_address,
+    }
+
+    result = await get_balance(request_)
+
+    assert expected_result == result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('invalid_public_key_address', ['12345', 12345, True])
+async def test_get_balance_with_invalid_address(request_, invalid_public_key_address):
+    """
+    Case: get balance with invalid address.
+    Expect: address is not of a blockchain token type error message.
+    """
+    request_.params = {
+        PUBLIC_KEY_ADDRESS: invalid_public_key_address,
+    }
+
+    with pytest.raises(RpcInvalidParamsError) as error:
+        await get_balance(request_)
+
+    assert 'Address is not of a blockchain token type.' == error.value.message
+
+
+@pytest.mark.asyncio
+async def test_get_balance_without_address(request_):
+    """
+    Case: get balance without address.
+    Expect: missed address error message.
+    """
+    request_.params = {
+        PUBLIC_KEY_ADDRESS: None,
+    }
+
+    with pytest.raises(RpcInvalidParamsError) as error:
+        await get_balance(request_)
+
+    assert 'Missed address.' == error.value.message
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Jira references
- Ticket (task) — https://remmeio.atlassian.net/browse/REM-1138

The solution to this bug was resolved in the ticket — #246 