### PR TITLE
WIP [REM-993] Write test for batch status.

### DIFF
--- a/remme/rpc_api/transaction.py
+++ b/remme/rpc_api/transaction.py
@@ -31,7 +31,7 @@ from remme.tp.__main__ import TP_HANDLERS
 from remme.clients.account import AccountClient
 from remme.clients.pub_key import PubKeyClient
 from remme.protos.transaction_pb2 import TransactionPayload
-from remme.shared.forms import ProtoForm, IdentifierForm, IdentifiersForm
+from remme.shared.forms import ProtoForm, IdentifierForm, IdentifiersForm, BatchIdentifierForm
 
 from .utils import validate_params
 
@@ -213,7 +213,7 @@ async def fetch_batch(request):
         raise KeyNotFound(f'Batch with id "{id}" not found')
 
 
-@validate_params(IdentifierForm)
+@validate_params(BatchIdentifierForm)
 async def get_batch_status(request):
     id = request.params['id']
 

--- a/remme/shared/forms/__init__.py
+++ b/remme/shared/forms/__init__.py
@@ -32,6 +32,7 @@ from .atomic_swap import (
 from .identifier import (
     IdentifierForm,
     IdentifiersForm,
+    BatchIdentifierForm,
 )
 from .personal import (
     NodePKForm,

--- a/remme/shared/forms/_fields.py
+++ b/remme/shared/forms/_fields.py
@@ -18,9 +18,7 @@ class AddressField(fields.StringField):
 class SwapIDField(fields.StringField):
 
     validators = [
-        validators.DataRequired(message='Missed swap_id'),
-        validators.Regexp('[0-9a-f]{64}',
-                          message='Incorrect atomic swap identifier.')
+        validators.Regexp('[0-9a-f]{64}', message='Given swap identifier is invalid')
     ]
 
 
@@ -30,4 +28,11 @@ class IDField(fields.StringField):
         validators.DataRequired(message='Missed id'),
         validators.Regexp('[0-9a-f]{128}',
                           message='Incorrect identifier.')
+    ]
+
+
+class BatchIdField(fields.StringField):
+
+    validators = [
+        validators.Regexp('[0-9a-f]{128}', message='Given batch identifier is invalid'),
     ]

--- a/remme/shared/forms/identifier.py
+++ b/remme/shared/forms/identifier.py
@@ -1,11 +1,15 @@
 from wtforms import fields, validators
 
 from .base import ProtoForm
-from ._fields import IDField
+from ._fields import IDField, BatchIdField
 
 
 class IdentifierForm(ProtoForm):
     id = IDField()
+
+
+class BatchIdentifierForm(ProtoForm):
+    id = BatchIdField()
 
 
 class IdentifiersForm(ProtoForm):

--- a/testing/unit/rpc/test_batch_status.py
+++ b/testing/unit/rpc/test_batch_status.py
@@ -1,0 +1,74 @@
+import pytest
+from aiohttp_json_rpc.exceptions import RpcInvalidParamsError
+
+from remme.rpc_api.transaction import get_batch_status
+from testing.utils._async import return_async_value
+
+
+ID = 'id'
+VALID_BATCH_ID = 'b2e08b7fd6e4568db5c3f8ed25a00f610ac9f3a1fec911c026cadccb3a5a1bd4' \
+                 '79da9f4e49b4eb9d28f17fefb925e64b447ab1c694e73a8871ab3120f09dd332'
+
+
+ERROR_INVALID_BATCH_ID = 'Given batch identifier is invalid'
+ERROR_MISSED_ID = 'Missed id'
+
+
+@pytest.mark.asyncio
+async def test_get_batch_status(mocker, request_):
+    """
+    Case: .
+    Expect: .
+    """
+    expected_result = []
+
+    mock_get_block_info = mocker.patch('remme.clients.basic.BasicClient.get_batch_status')
+    mock_get_block_info.return_value = return_async_value(expected_result)
+
+    request_.params = {
+        ID: VALID_BATCH_ID,
+    }
+
+    result = await get_batch_status(request_)
+
+    assert expected_result == result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'invalid_batch_id',
+    [
+        pytest.param(0, id='batch_id=0'),
+        pytest.param('0', id='batch_id="0"'),
+        pytest.param(False, id='batch_id=False'),
+        pytest.param('', id='batch_id=""'),
+        pytest.param(None, id='batch_id=None'),
+    ])
+async def test_get_batch_status_with_invalid_id(request_, invalid_batch_id):
+    """
+    Case: .
+    Expect: .
+    """
+    request_.params = {
+        ID: invalid_batch_id,
+    }
+
+    with pytest.raises(RpcInvalidParamsError) as error:
+        await get_batch_status(request_)
+
+    assert ERROR_INVALID_BATCH_ID == error.value.message
+
+
+@pytest.mark.asyncio
+async def test_get_batch_status_without_id(request_):
+    """
+    Case: .
+    Expect: .
+    """
+    request_.params = {
+    }
+
+    with pytest.raises(RpcInvalidParamsError) as error:
+        await get_batch_status(request_)
+
+    assert ERROR_MISSED_ID == error.value.message


### PR DESCRIPTION
Implements issue REM-993.
`Should return correct error message,for get_atomic_swap_info / get_batch_status -request with swap_id / id(batch) = 0`

Changes introduced in this pull request:

- write test for batch_status
- delete checks required fields
