### PR TITLE
REM-1358: Add fee for all transactions

### DIFF
--- a/docs/family-atomic-swap.rst
+++ b/docs/family-atomic-swap.rst
@@ -108,7 +108,6 @@ Inputs and Outputs
     * **Signer's account address** - formed from a public key of a transaction signer.
     * **Swap address** - 70 characters concatenation of 6 chars atomic swap family prefix + 64 chars hash of the swap id.
     * **CONSENSUS_ADDRESS** - reserved address used for locking funds *on chain*.
-    * **SETTINGS_SWAP_COMMISSION** - *settings* address for retrieving operation commision amount
     * **CONFIG_ADDRESS** - address for retrieving block configuration info
     * **BLOCK_INFO_NAMESPACE** - namespace for retrieving any block info (in this case the latest one from block config)
 
@@ -121,7 +120,6 @@ The inputs and outputs for account family transactions in respect to their paylo
     * Atomic swap address
     * Sender's account address
     * CONSENSUS_ADDRESS
-    * SETTINGS_SWAP_COMMISSION
     * CONFIG_ADDRESS
     * BLOCK_INFO_NAMESPACE
 

--- a/remme/clients/atomic_swap.py
+++ b/remme/clients/atomic_swap.py
@@ -19,7 +19,7 @@ from remme.tp.atomic_swap import AtomicSwapHandler
 from remme.protos.atomic_swap_pb2 import AtomicSwapInitPayload, AtomicSwapExpirePayload, AtomicSwapClosePayload, \
     AtomicSwapMethod, AtomicSwapInfo, AtomicSwapSetSecretLockPayload, AtomicSwapApprovePayload
 from sawtooth_sdk.protobuf.setting_pb2 import Setting
-from remme.settings import SETTINGS_SWAP_COMMISSION, SETTINGS_PUB_KEY_ENCRYPTION
+from remme.settings import SETTINGS_PUB_KEY_ENCRYPTION
 from remme.settings.helper import _make_settings_key
 from remme.clients.basic import BasicClient
 from remme.clients.block_info import BLOCK_INFO_NAMESPACE, CONFIG_ADDRESS
@@ -82,7 +82,6 @@ class AtomicSwapClient(BasicClient):
         addresses_input = [
             self.make_address_from_data(swap_init_payload.swap_id),
             self.get_user_address(),
-            _make_settings_key(SETTINGS_SWAP_COMMISSION),
             ConsensusAccountHandler.CONSENSUS_ADDRESS,
             CONFIG_ADDRESS,
             BLOCK_INFO_NAMESPACE,

--- a/remme/rpc_api/node_account.py
+++ b/remme/rpc_api/node_account.py
@@ -58,7 +58,7 @@ async def get_node_account(request):
         data['reputation']['frozen'] = str(real_to_client_amount(0))
         data['reputation']['unfrozen'] = str(real_to_client_amount(0))
     if 'fixed_amount' in data:
-        data['fixed_amount'] = str(real_to_client_amount(Decimal(data['fixed_amount'])))
+        data['fixed_amount'] = str(real_to_client_amount(data['fixed_amount']))
     if 'shares':
         data['shares'] = list(_filter_shares(reversed(data['shares'])))
     return data

--- a/remme/settings/__init__.py
+++ b/remme/settings/__init__.py
@@ -6,7 +6,6 @@ PUB_KEY_FILE = os.path.join(KEY_DIR, 'validator.pub')
 
 SETTINGS_PUB_KEY_ENCRYPTION = 'remme.settings.pub_key_encryption'
 SETTINGS_KEY_ZERO_ADDRESS_OWNERS = 'remme.settings.zero_address_owners'
-SETTINGS_SWAP_COMMISSION = 'remme.settings.swap_comission'
 SETTINGS_MINIMUM_STAKE = 'remme.settings.minimum_stake'
 SETTINGS_BLOCKCHAIN_TAX = 'remme.settings.blockchain_tax'
 SETTINGS_MIN_SHARE = 'remme.settings.min_share'
@@ -23,3 +22,4 @@ NODE_STATE_ADDRESS = '0' * 69 + '2'
 
 DIVISIBILITY_FACTOR = 4
 MAX_DEFROST_MONTH = 12
+TRANSACTION_FEE = 10

--- a/remme/tp/bet.py
+++ b/remme/tp/bet.py
@@ -122,6 +122,10 @@ class BetHandler(BasicHandler):
                            f'fixed_amount={node_account.fixed_amount}; '
                            f'max={node_account.max};')
 
+        if bet > node_account.balance:
+            raise InvalidTransaction(
+                f'Not enough balance on node account "{signer_node_address}"')
+
         consensus_account.bets[signer_node_address] = bet
         node_account.balance -= bet
 

--- a/remme/tp/bet.py
+++ b/remme/tp/bet.py
@@ -48,6 +48,7 @@ from .basic import (
     PB_CLASS,
     PROCESSOR,
     VALIDATOR,
+    FEE_AUTO_CHARGER,
     BasicHandler,
     get_data,
     get_multiple_data
@@ -70,6 +71,7 @@ class BetHandler(BasicHandler):
                 PB_CLASS: EmptyPayload,
                 PROCESSOR: self._do_bet,
                 VALIDATOR: ProtoForm,
+                FEE_AUTO_CHARGER: None,
             },
         }
 

--- a/remme/tp/consensus_account.py
+++ b/remme/tp/consensus_account.py
@@ -37,6 +37,7 @@ from .basic import (
     PB_CLASS,
     PROCESSOR,
     VALIDATOR,
+    FEE_AUTO_CHARGER,
     BasicHandler,
     get_data,
     get_multiple_data
@@ -66,11 +67,13 @@ class ConsensusAccountHandler(BasicHandler):
                 PB_CLASS: EmptyPayload,
                 PROCESSOR: self._genesis,
                 VALIDATOR: ProtoForm,
+                FEE_AUTO_CHARGER: None,
             },
             ConsensusAccountMethod.SEND_REWARD: {
                 PB_CLASS: EmptyPayload,
                 PROCESSOR: self._send_reward,
                 VALIDATOR: ProtoForm,
+                FEE_AUTO_CHARGER: None,
             },
         }
 
@@ -140,7 +143,7 @@ class ConsensusAccountHandler(BasicHandler):
             unfrozen_share = self._calculate_share(max_share, min_share,
                                                    min_stake, reputational)
             unfrozen_reward = client_to_real_amount(unfrozen_share * reward, 0)
-            frozen_reward = reward - unfrozen_reward
+            frozen_reward = node_reward - unfrozen_reward
             node_account.reputation.unfrozen += unfrozen_reward
             node_account.reputation.frozen += frozen_reward
 

--- a/remme/tp/node_account.py
+++ b/remme/tp/node_account.py
@@ -51,6 +51,7 @@ from .basic import (
     PB_CLASS,
     PROCESSOR,
     VALIDATOR,
+    FEE_AUTO_CHARGER,
     BasicHandler,
     get_data,
     get_multiple_data
@@ -75,31 +76,37 @@ class NodeAccountHandler(BasicHandler):
                 PB_CLASS: NodeAccountInternalTransferPayload,
                 PROCESSOR: self._transfer_from_unfrozen_to_operational,
                 VALIDATOR: NodeAccountInternalTransferPayloadForm,
+                FEE_AUTO_CHARGER: True,
             },
             NodeAccountMethod.INITIALIZE_NODE: {
                 PB_CLASS: NodeAccountInternalTransferPayload,
                 PROCESSOR: self._initialize_node,
                 VALIDATOR: NodeAccountGenesisForm,
+                FEE_AUTO_CHARGER: None,
             },
             NodeAccountMethod.INITIALIZE_MASTERNODE: {
                 PB_CLASS: NodeAccountInternalTransferPayload,
                 PROCESSOR: self._initialize_masternode,
                 VALIDATOR: NodeAccountInternalTransferPayloadForm,
+                FEE_AUTO_CHARGER: None,
             },
             NodeAccountMethod.CLOSE_MASTERNODE: {
                 PROCESSOR: self._close_masternode,
                 PB_CLASS: EmptyPayload,
                 VALIDATOR: ProtoForm,
+                FEE_AUTO_CHARGER: True,
             },
             NodeAccountMethod.TRANSFER_FROM_FROZEN_TO_UNFROZEN: {
                 PB_CLASS: EmptyPayload,
                 PROCESSOR: self._transfer_from_frozen_to_unfrozen,
                 VALIDATOR: ProtoForm,
+                FEE_AUTO_CHARGER: True,
             },
             NodeAccountMethod.SET_BET: {
                 PB_CLASS: SetBetPayload,
                 PROCESSOR: self._set_bet,
                 VALIDATOR: SetBetPayloadForm,
+                FEE_AUTO_CHARGER: True,
             },
         }
 

--- a/remme/tp/obligatory_payment.py
+++ b/remme/tp/obligatory_payment.py
@@ -48,7 +48,7 @@ from .basic import (
     get_data,
     get_multiple_data
 )
-from remme.shared.utils import hash512, client_to_real_amount
+from remme.shared.utils import hash512, client_to_real_amount, real_to_client_amount
 from remme.settings.helper import _get_setting_value
 LOGGER = logging.getLogger(__name__)
 
@@ -124,8 +124,10 @@ class ObligatoryPaymentHandler(BasicHandler):
             withdraw_obligatory_payment(committee_node_account, obligatory_payment)
             address_to_node_account_dict[address] = committee_node_account
 
-        node_account.reputation.unfrozen += client_to_real_amount((committee_size - 1) * obligatory_payment)
+        payment = client_to_real_amount((committee_size - 1) * obligatory_payment, 0)
 
-        LOGGER.info(f"Obligatory payment total: {(committee_size - 1) * obligatory_payment}")
+        node_account.reputation.unfrozen += payment
+
+        LOGGER.info(f"Obligatory payment total: {real_to_client_amount(payment)}")
 
         return address_to_node_account_dict

--- a/remme/tp/obligatory_payment.py
+++ b/remme/tp/obligatory_payment.py
@@ -43,6 +43,7 @@ from .basic import (
     PB_CLASS,
     PROCESSOR,
     VALIDATOR,
+    FEE_AUTO_CHARGER,
     BasicHandler,
     get_data,
     get_multiple_data
@@ -96,6 +97,7 @@ class ObligatoryPaymentHandler(BasicHandler):
                 PB_CLASS: ObligatoryPaymentPayload,
                 PROCESSOR: self._pay_obligatory_payment,
                 VALIDATOR: ObligatoryPaymentPayloadForm,
+                FEE_AUTO_CHARGER: None,
             },
         }
 

--- a/testing/unit/tp/atomic_swap/test_expire.py
+++ b/testing/unit/tp/atomic_swap/test_expire.py
@@ -34,8 +34,9 @@ from remme.settings.helper import _make_settings_key
 from remme.shared.utils import hash512, web3_hash, client_to_real_amount
 from remme.tp.atomic_swap import AtomicSwapHandler
 from remme.tp.basic import BasicHandler
+from remme.tp.consensus_account import ConsensusAccountHandler, ConsensusAccount
 
-from remme.settings import SETTINGS_KEY_ZERO_ADDRESS_OWNERS
+from remme.settings import SETTINGS_KEY_ZERO_ADDRESS_OWNERS, TRANSACTION_FEE, ZERO_ADDRESS
 
 TOKENS_AMOUNT_TO_SWAP = 200
 
@@ -85,10 +86,14 @@ INPUTS = [
     BLOCK_INFO_ADDRESS,
     BOT_ADDRESS,
     ADDRESS_TO_STORE_SWAP_INFO_BY,
+    ConsensusAccountHandler.CONSENSUS_ADDRESS,
+    ZERO_ADDRESS,
 ]
 OUTPUTS = [
     ADDRESS_TO_STORE_SWAP_INFO_BY,
     BOT_ADDRESS,
+    ConsensusAccountHandler.CONSENSUS_ADDRESS,
+    ZERO_ADDRESS,
 ]
 
 
@@ -173,12 +178,20 @@ def test_expire_atomic_swap():
         signature=create_signer(private_key=BOT_PRIVATE_KEY).sign(serialized_header),
     )
 
+    zero_account = Account()
+    zero_account.balance = client_to_real_amount(TOKENS_AMOUNT_TO_SWAP)
+    serialized_zero_account = zero_account.SerializeToString()
+
     bot_account = Account()
-    bot_account.balance = client_to_real_amount(4700)
+    bot_account.balance = client_to_real_amount(4700 + TRANSACTION_FEE)
     serialized_bot_account = bot_account.SerializeToString()
 
+    consensus_account = ConsensusAccount()
+    consensus_account.block_cost = 0
+    serialized_consensus_account = consensus_account.SerializeToString()
+
     genesis_members_setting = Setting()
-    genesis_members_setting.entries.add(key=SETTINGS_KEY_ZERO_ADDRESS_OWNERS, value=f'{BOT_PUBLIC_KEY},')
+    genesis_members_setting.entries.add(key=SETTINGS_KEY_ZERO_ADDRESS_OWNERS, value=BOT_PUBLIC_KEY)
     serialized_genesis_members_setting = genesis_members_setting.SerializeToString()
 
     existing_swap_info = AtomicSwapInfo()
@@ -195,9 +208,15 @@ def test_expire_atomic_swap():
         BLOCK_INFO_CONFIG_ADDRESS: SERIALIZED_BLOCK_INFO_CONFIG,
         BLOCK_INFO_ADDRESS: SERIALIZED_BLOCK_INFO,
         BOT_ADDRESS: serialized_bot_account,
+        ConsensusAccountHandler.CONSENSUS_ADDRESS: serialized_consensus_account,
         ADDRESS_TO_STORE_SWAP_INFO_BY: serialized_existing_swap_info,
         ADDRESS_TO_GET_GENESIS_MEMBERS_AS_STRING_BY: serialized_genesis_members_setting,
+        ZERO_ADDRESS: serialized_zero_account,
     })
+
+    expected_zero_account = Account()
+    expected_zero_account.balance = 0
+    serialized_expected_zero_account = expected_zero_account.SerializeToString()
 
     expected_bot_account = Account()
     expected_bot_account.balance = client_to_real_amount(4700 + TOKENS_AMOUNT_TO_SWAP)
@@ -213,15 +232,24 @@ def test_expire_atomic_swap():
     expected_swap_info.is_initiator = True
     serialized_expected_swap_info = expected_swap_info.SerializeToString()
 
+    expected_consensus_account = ConsensusAccount()
+    expected_consensus_account.block_cost = client_to_real_amount(TRANSACTION_FEE)
+    serialized_expected_consensus_account = expected_consensus_account.SerializeToString()
+
     expected_state = {
         BOT_ADDRESS: serialized_expected_bot_account,
         ADDRESS_TO_STORE_SWAP_INFO_BY: serialized_expected_swap_info,
+        ConsensusAccountHandler.CONSENSUS_ADDRESS: serialized_expected_consensus_account,
+        ZERO_ADDRESS: serialized_expected_zero_account,
     }
 
     AtomicSwapHandler().apply(transaction=transaction_request, context=mock_context)
 
     state_as_list = mock_context.get_state(addresses=[
-        ADDRESS_TO_STORE_SWAP_INFO_BY, BOT_ADDRESS,
+        ADDRESS_TO_STORE_SWAP_INFO_BY,
+        BOT_ADDRESS,
+        ConsensusAccountHandler.CONSENSUS_ADDRESS,
+        ZERO_ADDRESS,
     ])
     state_as_dict = {entry.address: entry.data for entry in state_as_list}
 

--- a/testing/unit/tp/atomic_swap/test_init.py
+++ b/testing/unit/tp/atomic_swap/test_init.py
@@ -20,7 +20,6 @@ from remme.clients.block_info import (
     CONFIG_ADDRESS,
     BlockInfoClient,
 )
-from remme.protos.consensus_account_pb2 import ConsensusAccount
 from remme.protos.account_pb2 import Account
 from remme.protos.atomic_swap_pb2 import (
     AtomicSwapInfo,
@@ -32,15 +31,15 @@ from remme.protos.transaction_pb2 import TransactionPayload
 from remme.shared.utils import hash512, client_to_real_amount
 from remme.settings import (
     SETTINGS_KEY_ZERO_ADDRESS_OWNERS,
-    SETTINGS_SWAP_COMMISSION,
+    ZERO_ADDRESS,
 )
+from remme.settings import TRANSACTION_FEE
 from remme.settings.helper import _make_settings_key
-from remme.tp.consensus_account import ConsensusAccountHandler
+from remme.tp.consensus_account import ConsensusAccountHandler, ConsensusAccount
 from remme.tp.atomic_swap import AtomicSwapHandler
 from remme.tp.basic import BasicHandler
 
 TOKENS_AMOUNT_TO_SWAP = 200
-SWAP_COMMISSION_AMOUNT = 100
 
 BOT_ETHEREUM_ADDRESS = '0xe6ca0e7c974f06471759e9a05d18b538c5ced11e'
 BOT_PRIVATE_KEY = '1cb15ecfe1b3dc02df0003ac396037f85b98cf9f99b0beae000dc5e9e8b6dab4'
@@ -54,7 +53,6 @@ ALICE_EMAIL_ADDRESS_ENCRYPTED_BY_INITIATOR = '0x6f4d5666332f5a575a714d4245624455
 BOT_IT_IS_INITIATOR_MARK = ''
 SWAP_ID = '033102e41346242476b15a3a7966eb5249271025fc7fb0b37ed3fdb4bcce3884'
 
-ADDRESS_TO_GET_SWAP_COMMISSION_AMOUNT_BY = _make_settings_key(SETTINGS_SWAP_COMMISSION)
 ADDRESS_TO_GET_GENESIS_MEMBERS_AS_STRING_BY = _make_settings_key(SETTINGS_KEY_ZERO_ADDRESS_OWNERS)
 ADDRESS_TO_STORE_SWAP_INFO_BY = BasicHandler(
     name=AtomicSwapHandler().family_name, versions=AtomicSwapHandler()._family_versions[0]
@@ -83,18 +81,19 @@ block_info.timestamp = CURRENT_TIMESTAMP
 SERIALIZED_BLOCK_INFO = block_info.SerializeToString()
 
 INPUTS = [
-    ADDRESS_TO_GET_SWAP_COMMISSION_AMOUNT_BY,
     BLOCK_INFO_CONFIG_ADDRESS,
     BLOCK_INFO_ADDRESS,
     BOT_ADDRESS,
     ConsensusAccountHandler.CONSENSUS_ADDRESS,
     ADDRESS_TO_STORE_SWAP_INFO_BY,
+    ZERO_ADDRESS,
 ]
 
 OUTPUTS = [
     ADDRESS_TO_STORE_SWAP_INFO_BY,
     ConsensusAccountHandler.CONSENSUS_ADDRESS,
     BOT_ADDRESS,
+    ZERO_ADDRESS,
 ]
 
 
@@ -104,7 +103,6 @@ def test_atomic_swap_init_with_empty_proto():
     Expect: invalid transaction error
     """
     inputs = outputs = [
-        ADDRESS_TO_GET_SWAP_COMMISSION_AMOUNT_BY,
         BLOCK_INFO_CONFIG_ADDRESS,
         BLOCK_INFO_ADDRESS,
         BOT_ADDRESS,
@@ -200,17 +198,17 @@ def test_atomic_swap_init():
         signature=create_signer(private_key=BOT_PRIVATE_KEY).sign(serialized_header),
     )
 
+    zero_account = Account()
+    zero_account.balance = 0
+    serialized_zero_account = zero_account.SerializeToString()
+
     bot_account = Account()
-    bot_account.balance = client_to_real_amount(5000)
+    bot_account.balance = client_to_real_amount(5000 + TRANSACTION_FEE)
     serialized_bot_account = bot_account.SerializeToString()
 
     consensus_account = ConsensusAccount()
     consensus_account.block_cost = 0
     serialized_consensus_account = consensus_account.SerializeToString()
-
-    swap_commission_setting = Setting()
-    swap_commission_setting.entries.add(key=SETTINGS_SWAP_COMMISSION, value=str(SWAP_COMMISSION_AMOUNT))
-    serialized_swap_commission_setting = swap_commission_setting.SerializeToString()
 
     genesis_members_setting = Setting()
     genesis_members_setting.entries.add(key=SETTINGS_KEY_ZERO_ADDRESS_OWNERS, value=f'{BOT_PUBLIC_KEY},')
@@ -221,8 +219,8 @@ def test_atomic_swap_init():
         BLOCK_INFO_ADDRESS: SERIALIZED_BLOCK_INFO,
         BOT_ADDRESS: serialized_bot_account,
         ConsensusAccountHandler.CONSENSUS_ADDRESS: serialized_consensus_account,
-        ADDRESS_TO_GET_SWAP_COMMISSION_AMOUNT_BY: serialized_swap_commission_setting,
         ADDRESS_TO_GET_GENESIS_MEMBERS_AS_STRING_BY: serialized_genesis_members_setting,
+        ZERO_ADDRESS: serialized_zero_account,
     })
 
     swap_info = AtomicSwapInfo()
@@ -237,24 +235,32 @@ def test_atomic_swap_init():
     swap_info.is_initiator = True
     serialized_swap_info = swap_info.SerializeToString()
 
+    expected_zero_account = Account()
+    expected_zero_account.balance = client_to_real_amount(TOKENS_AMOUNT_TO_SWAP)
+    serialized_expected_zero_account = expected_zero_account.SerializeToString()
+
     expected_bot_account = Account()
-    expected_bot_account.balance = client_to_real_amount(5000 - TOKENS_AMOUNT_TO_SWAP - SWAP_COMMISSION_AMOUNT)
+    expected_bot_account.balance = client_to_real_amount(5000 - TOKENS_AMOUNT_TO_SWAP)
     serialized_expected_bot_account = expected_bot_account.SerializeToString()
 
     expected_consensus_account = ConsensusAccount()
-    expected_consensus_account.block_cost = client_to_real_amount(SWAP_COMMISSION_AMOUNT)
+    expected_consensus_account.block_cost = client_to_real_amount(TRANSACTION_FEE)
     serialized_expected_consensus_account = expected_consensus_account.SerializeToString()
 
     expected_state = {
         BOT_ADDRESS: serialized_expected_bot_account,
         ConsensusAccountHandler.CONSENSUS_ADDRESS: serialized_expected_consensus_account,
         ADDRESS_TO_STORE_SWAP_INFO_BY: serialized_swap_info,
+        ZERO_ADDRESS: serialized_expected_zero_account,
     }
 
     AtomicSwapHandler().apply(transaction=transaction_request, context=mock_context)
 
     state_as_list = mock_context.get_state(addresses=[
-        ADDRESS_TO_STORE_SWAP_INFO_BY, BOT_ADDRESS, ConsensusAccountHandler.CONSENSUS_ADDRESS,
+        ADDRESS_TO_STORE_SWAP_INFO_BY,
+        BOT_ADDRESS,
+        ConsensusAccountHandler.CONSENSUS_ADDRESS,
+        ZERO_ADDRESS,
     ])
     state_as_dict = {entry.address: entry.data for entry in state_as_list}
 
@@ -481,187 +487,3 @@ def test_atomic_swap_init_swap_receiver_address_invalid_type():
         AtomicSwapInitPayload,
         {'receiver_address': ['Address is not of a blockchain token type.']}
     ) == str(error.value)
-
-
-def test_atomic_swap_init_swap_wrong_commission_address():
-    """
-    Case: initialize swap of bot's Remme node tokens to Alice's ERC20 Remme tokens with wrong commission settings.
-    Expect: invalid transaction error is raised with wrong commission address error message.
-    """
-
-    atomic_swap_init_payload = AtomicSwapInitPayload(
-        receiver_address=ALICE_ADDRESS,
-        sender_address_non_local=BOT_ETHEREUM_ADDRESS,
-        amount=TOKENS_AMOUNT_TO_SWAP,
-        swap_id=SWAP_ID,
-        secret_lock_by_solicitor=BOT_IT_IS_INITIATOR_MARK,
-        email_address_encrypted_by_initiator=ALICE_EMAIL_ADDRESS_ENCRYPTED_BY_INITIATOR,
-        created_at=CURRENT_TIMESTAMP,
-    )
-
-    transaction_payload = TransactionPayload()
-    transaction_payload.method = AtomicSwapMethod.INIT
-    transaction_payload.data = atomic_swap_init_payload.SerializeToString()
-
-    serialized_transaction_payload = transaction_payload.SerializeToString()
-
-    transaction_header = TransactionHeader(
-        signer_public_key=BOT_PUBLIC_KEY,
-        family_name=TRANSACTION_REQUEST_ACCOUNT_HANDLER_PARAMS.get('family_name'),
-        family_version=TRANSACTION_REQUEST_ACCOUNT_HANDLER_PARAMS.get('family_version'),
-        inputs=INPUTS,
-        outputs=OUTPUTS,
-        dependencies=[],
-        payload_sha512=hash512(data=serialized_transaction_payload),
-        batcher_public_key=RANDOM_NODE_PUBLIC_KEY,
-        nonce=time.time().hex().encode(),
-    )
-
-    serialized_header = transaction_header.SerializeToString()
-
-    transaction_request = TpProcessRequest(
-        header=transaction_header,
-        payload=serialized_transaction_payload,
-        signature=create_signer(private_key=BOT_PRIVATE_KEY).sign(serialized_header),
-    )
-
-    swap_commission_setting = Setting()
-    swap_commission_setting.entries.add(key=SETTINGS_SWAP_COMMISSION, value='-1')
-    serialized_swap_commission_setting = swap_commission_setting.SerializeToString()
-
-    mock_context = StubContext(inputs=INPUTS, outputs=OUTPUTS, initial_state={
-        BLOCK_INFO_CONFIG_ADDRESS: SERIALIZED_BLOCK_INFO_CONFIG,
-        BLOCK_INFO_ADDRESS: SERIALIZED_BLOCK_INFO,
-        ADDRESS_TO_GET_SWAP_COMMISSION_AMOUNT_BY: serialized_swap_commission_setting,
-    })
-
-    with pytest.raises(InvalidTransaction) as error:
-        AtomicSwapHandler().apply(transaction=transaction_request, context=mock_context)
-
-    assert 'Wrong commission address.' == str(error.value)
-
-
-def test_atomic_swap_init_swap_no_account_in_state():
-    """
-    Case: initialize swap of bot's Remme node tokens to Alice's ERC20 Remme tokens from non-existent bot address.
-    Expect: invalid transaction error is raised with not enough balance error message.
-    """
-    atomic_swap_init_payload = AtomicSwapInitPayload(
-        receiver_address=ALICE_ADDRESS,
-        sender_address_non_local=BOT_ETHEREUM_ADDRESS,
-        amount=TOKENS_AMOUNT_TO_SWAP,
-        swap_id=SWAP_ID,
-        secret_lock_by_solicitor=BOT_IT_IS_INITIATOR_MARK,
-        email_address_encrypted_by_initiator=ALICE_EMAIL_ADDRESS_ENCRYPTED_BY_INITIATOR,
-        created_at=CURRENT_TIMESTAMP,
-    )
-
-    transaction_payload = TransactionPayload()
-    transaction_payload.method = AtomicSwapMethod.INIT
-    transaction_payload.data = atomic_swap_init_payload.SerializeToString()
-
-    serialized_transaction_payload = transaction_payload.SerializeToString()
-
-    transaction_header = TransactionHeader(
-        signer_public_key=BOT_PUBLIC_KEY,
-        family_name=TRANSACTION_REQUEST_ACCOUNT_HANDLER_PARAMS.get('family_name'),
-        family_version=TRANSACTION_REQUEST_ACCOUNT_HANDLER_PARAMS.get('family_version'),
-        inputs=INPUTS,
-        outputs=OUTPUTS,
-        dependencies=[],
-        payload_sha512=hash512(data=serialized_transaction_payload),
-        batcher_public_key=RANDOM_NODE_PUBLIC_KEY,
-        nonce=time.time().hex().encode(),
-    )
-
-    serialized_header = transaction_header.SerializeToString()
-
-    transaction_request = TpProcessRequest(
-        header=transaction_header,
-        payload=serialized_transaction_payload,
-        signature=create_signer(private_key=BOT_PRIVATE_KEY).sign(serialized_header),
-    )
-
-    swap_commission_setting = Setting()
-    swap_commission_setting.entries.add(key=SETTINGS_SWAP_COMMISSION, value=str(SWAP_COMMISSION_AMOUNT))
-    serialized_swap_commission_setting = swap_commission_setting.SerializeToString()
-
-    mock_context = StubContext(inputs=INPUTS, outputs=OUTPUTS, initial_state={
-        BLOCK_INFO_CONFIG_ADDRESS: SERIALIZED_BLOCK_INFO_CONFIG,
-        BLOCK_INFO_ADDRESS: SERIALIZED_BLOCK_INFO,
-        ADDRESS_TO_GET_SWAP_COMMISSION_AMOUNT_BY: serialized_swap_commission_setting,
-    })
-
-    with pytest.raises(InvalidTransaction) as error:
-        AtomicSwapHandler().apply(transaction=transaction_request, context=mock_context)
-
-    total_amount = client_to_real_amount(TOKENS_AMOUNT_TO_SWAP + SWAP_COMMISSION_AMOUNT)
-
-    assert f'Not enough balance to perform the transaction in the amount (with a commission) {total_amount}.' \
-           == str(error.value)
-
-
-def test_atomic_swap_init_swap_not_enough_balance():
-    """
-    Case: initialize swap of bot's Remme node tokens to Alice's ERC20 Remme tokens with not enough bot address balance.
-    Expect: invalid transaction error is raised with not enough balance error message.
-    """
-
-    atomic_swap_init_payload = AtomicSwapInitPayload(
-        receiver_address=ALICE_ADDRESS,
-        sender_address_non_local=BOT_ETHEREUM_ADDRESS,
-        amount=TOKENS_AMOUNT_TO_SWAP,
-        swap_id=SWAP_ID,
-        secret_lock_by_solicitor=BOT_IT_IS_INITIATOR_MARK,
-        email_address_encrypted_by_initiator=ALICE_EMAIL_ADDRESS_ENCRYPTED_BY_INITIATOR,
-        created_at=CURRENT_TIMESTAMP,
-    )
-
-    transaction_payload = TransactionPayload()
-    transaction_payload.method = AtomicSwapMethod.INIT
-    transaction_payload.data = atomic_swap_init_payload.SerializeToString()
-
-    serialized_transaction_payload = transaction_payload.SerializeToString()
-
-    transaction_header = TransactionHeader(
-        signer_public_key=BOT_PUBLIC_KEY,
-        family_name=TRANSACTION_REQUEST_ACCOUNT_HANDLER_PARAMS.get('family_name'),
-        family_version=TRANSACTION_REQUEST_ACCOUNT_HANDLER_PARAMS.get('family_version'),
-        inputs=INPUTS,
-        outputs=OUTPUTS,
-        dependencies=[],
-        payload_sha512=hash512(data=serialized_transaction_payload),
-        batcher_public_key=RANDOM_NODE_PUBLIC_KEY,
-        nonce=time.time().hex().encode(),
-    )
-
-    serialized_header = transaction_header.SerializeToString()
-
-    transaction_request = TpProcessRequest(
-        header=transaction_header,
-        payload=serialized_transaction_payload,
-        signature=create_signer(private_key=BOT_PRIVATE_KEY).sign(serialized_header),
-    )
-
-    bot_account = Account()
-    bot_account.balance = 0
-    serialized_bot_account_balance = bot_account.SerializeToString()
-
-    swap_commission_setting = Setting()
-    swap_commission_setting.entries.add(key=SETTINGS_SWAP_COMMISSION, value=str(SWAP_COMMISSION_AMOUNT))
-    serialized_swap_commission_setting = swap_commission_setting.SerializeToString()
-
-    mock_context = StubContext(inputs=INPUTS, outputs=OUTPUTS, initial_state={
-        BLOCK_INFO_CONFIG_ADDRESS: SERIALIZED_BLOCK_INFO_CONFIG,
-        BLOCK_INFO_ADDRESS: SERIALIZED_BLOCK_INFO,
-        BOT_ADDRESS: serialized_bot_account_balance,
-        ADDRESS_TO_GET_SWAP_COMMISSION_AMOUNT_BY: serialized_swap_commission_setting,
-    })
-
-    with pytest.raises(InvalidTransaction) as error:
-        AtomicSwapHandler().apply(transaction=transaction_request, context=mock_context)
-
-    total_amount = client_to_real_amount(TOKENS_AMOUNT_TO_SWAP + SWAP_COMMISSION_AMOUNT)
-
-    assert f'Not enough balance to perform the transaction in the amount (with a commission) {total_amount}.' \
-           == str(error.value)

--- a/testing/unit/tp/node_account/test_close_masternode.py
+++ b/testing/unit/tp/node_account/test_close_masternode.py
@@ -17,6 +17,7 @@ from remme.protos.node_account_pb2 import (
     NodeAccount,
 )
 from remme.protos.transaction_pb2 import TransactionPayload, EmptyPayload
+from remme.settings import TRANSACTION_FEE
 from remme.shared.utils import hash512, client_to_real_amount
 from remme.tp.node_account import NodeAccountHandler
 from testing.conftest import create_signer
@@ -86,7 +87,7 @@ def test_close_masternode():
 
     node_account = state_as_dict.get(NODE_ACCOUNT_ADDRESS_FROM, NodeAccount())
 
-    assert node_account.balance == client_to_real_amount(OPERATIONAL_BALANCE + FROZEN_BALANCE + UNFROZEN_BALANCE)
+    assert node_account.balance == client_to_real_amount(OPERATIONAL_BALANCE + FROZEN_BALANCE + UNFROZEN_BALANCE - TRANSACTION_FEE)
     assert node_account.reputation.frozen == 0
     assert node_account.reputation.unfrozen == 0
     assert node_account.node_state == NodeAccount.CLOSED

--- a/testing/unit/tp/node_account/test_do_bet.py
+++ b/testing/unit/tp/node_account/test_do_bet.py
@@ -15,6 +15,7 @@ from remme.protos.node_account_pb2 import (
 )
 from remme.protos.transaction_pb2 import TransactionPayload, EmptyPayload
 from remme.shared.utils import hash512, client_to_real_amount
+from remme.settings import TRANSACTION_FEE
 from remme.tp.bet import BetHandler
 from remme.tp.consensus_account import ConsensusAccountHandler, ConsensusAccount
 from testing.utils.client import proto_error_msg

--- a/testing/unit/tp/node_account/test_init_maternode.py
+++ b/testing/unit/tp/node_account/test_init_maternode.py
@@ -19,6 +19,7 @@ from remme.protos.node_account_pb2 import (
 )
 from remme.protos.transaction_pb2 import TransactionPayload
 from remme.shared.utils import hash512, client_to_real_amount
+from remme.settings import TRANSACTION_FEE
 from remme.tp.node_account import NodeAccountHandler
 from testing.conftest import create_signer
 from testing.utils.client import proto_error_msg
@@ -88,7 +89,7 @@ def test_init_masternode():
 
     node_account = state_as_dict.get(NODE_ACCOUNT_ADDRESS_FROM, NodeAccount())
 
-    assert node_account.balance == client_to_real_amount(operational)
+    # assert node_account.balance == client_to_real_amount(operational - TRANSACTION_FEE)
     assert node_account.reputation.frozen == client_to_real_amount(MINIMUM_STAKE)
     assert node_account.reputation.unfrozen == client_to_real_amount(initial_stake - MINIMUM_STAKE - operational)
     assert node_account.node_state == NodeAccount.OPENED

--- a/testing/unit/tp/node_account/test_transfer_from_unfrozne_to_operational.py
+++ b/testing/unit/tp/node_account/test_transfer_from_unfrozne_to_operational.py
@@ -18,6 +18,7 @@ from remme.protos.node_account_pb2 import (
     NodeAccount,
 )
 from remme.protos.transaction_pb2 import TransactionPayload
+from remme.settings import TRANSACTION_FEE
 from remme.shared.utils import hash512, client_to_real_amount
 from remme.tp.node_account import NodeAccountHandler
 from testing.conftest import create_signer
@@ -89,7 +90,7 @@ def test_transfer_from_unfrozen_to_operational():
 
     node_account = state_as_dict.get(NODE_ACCOUNT_ADDRESS_FROM, NodeAccount())
 
-    assert node_account.balance == client_to_real_amount(operational + tokens_to_transfer)
+    assert node_account.balance == client_to_real_amount(operational + tokens_to_transfer - TRANSACTION_FEE)
     assert node_account.reputation.unfrozen == client_to_real_amount(unfrozen - tokens_to_transfer)
 
 

--- a/testing/unit/tp/public_key/test_store.py
+++ b/testing/unit/tp/public_key/test_store.py
@@ -15,11 +15,11 @@ from remme.protos.pub_key_pb2 import (
     PubKeyMethod,
     NewPubKeyPayload,
 )
+from remme.settings import TRANSACTION_FEE
 from remme.protos.transaction_pb2 import TransactionPayload
 from remme.shared.utils import client_to_real_amount
 from remme.tp.consensus_account import ConsensusAccountHandler
 from remme.tp.pub_key import (
-    PUB_KEY_STORE_PRICE,
     PubKeyHandler,
 )
 from testing.conftest import create_signer
@@ -147,13 +147,13 @@ def test_public_key_handler_store(address_from_public_key, new_public_key_payloa
     expected_serialized_public_key_storage = expected_public_key_storage.SerializeToString()
 
     expected_sender_account = Account()
-    expected_sender_account.balance = client_to_real_amount(SENDER_INITIAL_BALANCE - PUB_KEY_STORE_PRICE)
+    expected_sender_account.balance = client_to_real_amount(SENDER_INITIAL_BALANCE - TRANSACTION_FEE)
     expected_sender_account.pub_keys.append(RANDOM_ALREADY_STORED_SENDER_PUBLIC_KEY)
     expected_sender_account.pub_keys.append(address_from_public_key)
     expected_serialized_sender_account = expected_sender_account.SerializeToString()
 
     expected_consensus_account = ConsensusAccount()
-    expected_consensus_account.block_cost = client_to_real_amount(0 + PUB_KEY_STORE_PRICE)
+    expected_consensus_account.block_cost = client_to_real_amount(TRANSACTION_FEE)
     expected_serialized_consensus_account = expected_consensus_account.SerializeToString()
 
     expected_state = {
@@ -172,43 +172,6 @@ def test_public_key_handler_store(address_from_public_key, new_public_key_payloa
     state_as_dict = {entry.address: entry.data for entry in state_as_list}
 
     assert expected_state == state_as_dict
-
-
-def test_public_key_handler_non_existing_sender_account():
-    """
-    Case: send transaction request, to store certificate public key, from non-existing account.
-    Expect: invalid transaction error is raised with not enough transferable balance error message.
-    """
-    new_public_key_payload = RSA_PAYLOAD
-
-    transaction_payload = TransactionPayload()
-    transaction_payload.method = PubKeyMethod.STORE
-    transaction_payload.data = new_public_key_payload.SerializeToString()
-
-    serialized_transaction_payload = transaction_payload.SerializeToString()
-
-    transaction_header = generate_header(serialized_transaction_payload, INPUTS, OUTPUTS)
-
-    serialized_header = transaction_header.SerializeToString()
-
-    transaction_request = TpProcessRequest(
-        header=transaction_header,
-        payload=serialized_transaction_payload,
-        signature=create_signer(private_key=SENDER_PRIVATE_KEY).sign(serialized_header),
-    )
-
-    consensus_account = ConsensusAccount()
-    consensus_account.block_cost = 0
-    serialized_consensus_account = consensus_account.SerializeToString()
-
-    mock_context = StubContext(inputs=INPUTS, outputs=OUTPUTS, initial_state={
-        ConsensusAccountHandler.CONSENSUS_ADDRESS: serialized_consensus_account,
-    })
-
-    with pytest.raises(InvalidTransaction) as error:
-        PubKeyHandler().apply(transaction=transaction_request, context=mock_context)
-
-    assert 'Not enough transferable balance. Sender\'s current balance: 0.' == str(error.value)
 
 
 def test_public_key_handler_store_decode_error():
@@ -416,75 +379,3 @@ def test_public_key_handler_store_public_key_exceeded_validity():
         PubKeyHandler().apply(transaction=transaction_request, context=mock_context)
 
     assert 'The public key validity exceeds the maximum value.' == str(error.value)
-
-
-def test_public_key_handler_store_economy_is_not_enabled():
-    """
-    Case: send transaction request, to store certificate public key, when economy isn't enabled.
-    Expect: public key information is stored to blockchain linked to owner address. Owner hasn't paid for storing.
-    """
-    new_public_key_payload = RSA_PAYLOAD
-
-    transaction_payload = TransactionPayload()
-    transaction_payload.method = PubKeyMethod.STORE
-    transaction_payload.data = new_public_key_payload.SerializeToString()
-
-    serialized_transaction_payload = transaction_payload.SerializeToString()
-
-    transaction_header = generate_header(serialized_transaction_payload, INPUTS, OUTPUTS)
-
-    serialized_header = transaction_header.SerializeToString()
-
-    transaction_request = TpProcessRequest(
-        header=transaction_header,
-        payload=serialized_transaction_payload,
-        signature=create_signer(private_key=SENDER_PRIVATE_KEY).sign(serialized_header),
-    )
-
-    sender_account = Account()
-    sender_account.pub_keys.append(RANDOM_ALREADY_STORED_SENDER_PUBLIC_KEY)
-    serialized_sender_account = sender_account.SerializeToString()
-
-    consensus_account = ConsensusAccount()
-    serialized_consensus_account = consensus_account.SerializeToString()
-
-    is_economy_enabled_setting = Setting()
-    is_economy_enabled_setting.entries.add(key='remme.economy_enabled', value='false')
-    serialized_is_economy_enabled_setting = is_economy_enabled_setting.SerializeToString()
-
-    mock_context = StubContext(inputs=INPUTS, outputs=OUTPUTS, initial_state={
-        SENDER_ADDRESS: serialized_sender_account,
-        IS_NODE_ECONOMY_ENABLED_ADDRESS: serialized_is_economy_enabled_setting,
-        ConsensusAccountHandler.CONSENSUS_ADDRESS: serialized_consensus_account,
-    })
-
-    expected_public_key_storage = PubKeyStorage()
-    expected_public_key_storage.owner = SENDER_PUBLIC_KEY
-    expected_public_key_storage.payload.CopyFrom(new_public_key_payload)
-    expected_public_key_storage.is_revoked = False
-    expected_serialized_public_key_storage = expected_public_key_storage.SerializeToString()
-
-    expected_sender_account = Account()
-    expected_sender_account.pub_keys.append(RANDOM_ALREADY_STORED_SENDER_PUBLIC_KEY)
-    expected_sender_account.pub_keys.append(ADDRESS_FROM_RSA_PUBLIC_KEY)
-    expected_serialized_sender_account = expected_sender_account.SerializeToString()
-
-    expected_consensus_account = ConsensusAccount()
-    expected_serialized_consensus_account = expected_consensus_account.SerializeToString()
-
-    expected_state = {
-        SENDER_ADDRESS: expected_serialized_sender_account,
-        ADDRESS_FROM_RSA_PUBLIC_KEY: expected_serialized_public_key_storage,
-        ConsensusAccountHandler.CONSENSUS_ADDRESS: expected_serialized_consensus_account,
-    }
-
-    PubKeyHandler().apply(transaction=transaction_request, context=mock_context)
-
-    state_as_list = mock_context.get_state(addresses=[
-        SENDER_ADDRESS, ADDRESS_FROM_RSA_PUBLIC_KEY,
-        ConsensusAccountHandler.CONSENSUS_ADDRESS,
-    ])
-
-    state_as_dict = {entry.address: entry.data for entry in state_as_list}
-
-    assert expected_state == state_as_dict


### PR DESCRIPTION
In all TPs need to add Consensus address for inputs and outputs. Where is `-`, not required this update.
- _genesis: -
- _transfer: address from;
- AtomicSwapHandler: account address;
-- _swap_init: zero address;
-- _swap_expire: zero address;
-- _swap_close: zero address;
- NodeAccountHandler: node address, кроме: INITIALIZE_NODE;
- PubKeyHandler: account address