### PR TITLE
cache block response and reduce requests

### DIFF
--- a/remme/clients/block_info.py
+++ b/remme/clients/block_info.py
@@ -15,13 +15,21 @@ BLOCK_INFO_NAMESPACE = NAMESPACE + '00'
 
 class BlockInfoClient(BasicClient):
 
-    async def get_block_info_states(self, block_num, limit):
+    async def get_block_info_states(self, start, limit):
         states = await self.list_state(BLOCK_INFO_NAMESPACE, start, limit)
         return states['data']
+
+    async def get_blocks_for_block_info(self, start, limit):
+        blocks = await self.list_blocks(
+            start=f'0x{start}',
+            limit=limit,
+            reverse='',
+        )
+        return blocks['data']
     
     def get_block_info(self, state):
         bi = BlockInfo()
-        bi.ParseFromString(state)
+        bi.ParseFromString(base64.b64decode(state))
         return bi
 
     async def get_blocks_info(self, start, limit):
@@ -33,35 +41,36 @@ class BlockInfoClient(BasicClient):
         except Exception:
             return []
 
-        start = self.create_block_address(block_config.oldest_block if not init_start else start - 1)
+        start = block_config.oldest_block if not init_start else start
 
-        limit = min(block_config.latest_block if not init_limit else limit - 1, 100)
+        limit = min(block_config.latest_block + 2 if not init_limit else limit, 100)
 
         end = min(start + limit, block_config.latest_block) + 1
-        
+
+        LOGGER.debug(f'start: {start}, limit: {limit}, end: {end}')
+
+        start_block = self.create_block_address(start)
         # get all BlockInfo from states with given start (address of BlockInfo) and limit (number of items)
-        states = await self.get_block_info_states(start, limit)
+        states = await self.get_block_info_states(start_block, limit)
         # get all Blocks from start to limit.
         # Parameter start should correspond to this pattern 0x[a-f0-9]{16}.
         # Start is address of BlockInfo which has namespace and in the ending hex from block_num. 
         # So we should:
         # 1. get last 16 value from start as we need for list_blocks start parameter
         # 2. parse to int
-        # 3. add 1 for start from next block (because we don't need first block
+        # 3. add 2 for start from next block (because we don't need first block)
         # 4. parse to hex and ignore "0x"
         # 5. concatenate with 16 zeros (because we need 16 symbols and we don't know what length of our hex)
         # 6. get 16 value from concatenating string.
-        start_for_list_blocks = f'0000000000000000{hex(int(start[:16], 16) + 1)[2:]}'[:16]
-        # We should grab next block after limit because it's need for parsing last block for limit.
-        limit_for_list_blocks = limit + 1
-        blocks = (await self.list_blocks(start=f'0x{start_for_list_blocks}', limit=limit_for_list_blocks, reverse=''))['data']
+        start_for_list_blocks = f'0000000000000000{hex(int(start_block[-16:], 16) + 1)[2:]}'[-16:]
+        blocks = await self.get_blocks_for_block_info(start_for_list_blocks, limit)
         
         blocks_info = []
         for index, value in enumerate(states):
             bi = self.get_block_info(value['data'])
             
             try:
-                nc = bi.block_num + 1
+                nc = bi.block_num
                 if nc == block_config.latest_block + 1:
                     # for last taking votes from memory
                     seal_votes = await self.get_seal_for_last_block()
@@ -120,7 +129,7 @@ class BlockInfoClient(BasicClient):
     @staticmethod
     def interpret_block_info(block_info, votes):
         return {
-            "block_number": block_info.block_num + 1,
+            "block_number": block_info.block_num,
             "timestamp": block_info.timestamp,
             "previous_header_signature": block_info.previous_block_id,
             "signer_public_key": block_info.signer_public_key,

--- a/remme/clients/block_info.py
+++ b/remme/clients/block_info.py
@@ -43,7 +43,7 @@ class BlockInfoClient(BasicClient):
 
         start = block_config.oldest_block if not init_start else start
 
-        limit = min(block_config.latest_block + 2 if not init_limit else limit, 100)
+        limit = min(block_config.latest_block + 1 if not init_limit else limit, 100)
 
         end = min(start + limit, block_config.latest_block) + 1
 

--- a/remme/clients/block_info.py
+++ b/remme/clients/block_info.py
@@ -15,11 +15,13 @@ BLOCK_INFO_NAMESPACE = NAMESPACE + '00'
 
 class BlockInfoClient(BasicClient):
 
-    async def get_block_info(self, block_num):
+    async def get_block_info_states(self, block_num, limit):
+        states = await self.list_state(BLOCK_INFO_NAMESPACE, start, limit)
+        return states['data']
+    
+    def get_block_info(self, state):
         bi = BlockInfo()
-        bi_addr = self.create_block_address(block_num)
-        bi_state = await self.get_value(bi_addr)
-        bi.ParseFromString(bi_state)
+        bi.ParseFromString(state)
         return bi
 
     async def get_blocks_info(self, start, limit):
@@ -31,32 +33,42 @@ class BlockInfoClient(BasicClient):
         except Exception:
             return []
 
-        start = block_config.oldest_block if not init_start else start - 1
+        start = self.create_block_address(block_config.oldest_block if not init_start else start - 1)
 
         limit = min(block_config.latest_block if not init_limit else limit - 1, 100)
 
         end = min(start + limit, block_config.latest_block) + 1
         
-        pbi = None
+        # get all BlockInfo from states with given start (address of BlockInfo) and limit (number of items)
+        states = await self.get_block_info_states(start, limit)
+        # get all Blocks from start to limit.
+        # Parameter start should correspond to this pattern 0x[a-f0-9]{16}.
+        # Start is address of BlockInfo which has namespace and in the ending hex from block_num. 
+        # So we should:
+        # 1. get last 16 value from start as we need for list_blocks start parameter
+        # 2. parse to int
+        # 3. add 1 for start from next block (because we don't need first block
+        # 4. parse to hex and ignore "0x"
+        # 5. concatenate with 16 zeros (because we need 16 symbols and we don't know what length of our hex)
+        # 6. get 16 value from concatenating string.
+        start_for_list_blocks = f'0000000000000000{hex(int(start[:16], 16) + 1)[2:]}'[:16]
+        # We should grab next block after limit because it's need for parsing last block for limit.
+        limit_for_list_blocks = limit + 1
+        blocks = (await self.list_blocks(start=f'0x{start_for_list_blocks}', limit_for_list_blocks, reverse=''))['data']
         
-        async def _get_block_data(i, end):
+        blocks_info = []
+        for index, value in enumerate(states):
+            bi = self.get_block_info(value['data'])
+            
             try:
-                bi = pbi or await self.get_block_info(i)
-            except Exception as e:
-                LOGGER.exception(e)
-                return
-
-            try:
-                nc = i + 1
-                if nc == end:
+                nc = bi.block_num + 1
+                if nc == block_config.latest_block + 1:
                     # for last taking votes from memory
                     seal_votes = await self.get_seal_for_last_block()
                     votes = seal_votes['data']
                 else:
                     # other got from next one
-                    pbi = await self.get_block_info(nc)
-                    block = await self.list_blocks([pbi.header_signature])
-                    votes = block['data'][0]['header']['consensus']['previous_cert_votes']
+                    votes = blocks[index]['header']['consensus']['previous_cert_votes']
             except KeyNotFound:
                 # error occured in zero block, because of non existing address,
                 # block was mined through through initial deploy
@@ -67,17 +79,16 @@ class BlockInfoClient(BasicClient):
 
             self.parse_votes(votes)
 
-            return self.interpret_block_info(bi, votes)
-
-        blocks = await asyncio.gather(*(_get_block_data(i, end) for i in range(start, end)))
-        blocks = list(filter(None, blocks))
+            blocks_info.append(self.interpret_block_info(bi, votes))
+        
+        blocks_info = list(filter(None, blocks_info))
 
         next_ = None
         if end < block_config.latest_block + 1:
-            next_ = blocks[0]['block_number'] + 1
+            next_ = blocks_info[0]['block_number'] + 1
 
         return {
-            "data": list(reversed(blocks)),
+            "data": list(reversed(blocks_info)),
             "paging": {
                 "next": next_,
                 "start": init_start,

--- a/remme/clients/block_info.py
+++ b/remme/clients/block_info.py
@@ -54,7 +54,7 @@ class BlockInfoClient(BasicClient):
         start_for_list_blocks = f'0000000000000000{hex(int(start[:16], 16) + 1)[2:]}'[:16]
         # We should grab next block after limit because it's need for parsing last block for limit.
         limit_for_list_blocks = limit + 1
-        blocks = (await self.list_blocks(start=f'0x{start_for_list_blocks}', limit_for_list_blocks, reverse=''))['data']
+        blocks = (await self.list_blocks(start=f'0x{start_for_list_blocks}', limit=limit_for_list_blocks, reverse=''))['data']
         
         blocks_info = []
         for index, value in enumerate(states):

--- a/remme/clients/block_info.py
+++ b/remme/clients/block_info.py
@@ -36,10 +36,12 @@ class BlockInfoClient(BasicClient):
         limit = min(block_config.latest_block if not init_limit else limit - 1, 100)
 
         end = min(start + limit, block_config.latest_block) + 1
-
+        
+        pbi = None
+        
         async def _get_block_data(i, end):
             try:
-                bi = await self.get_block_info(i)
+                bi = pbi or await self.get_block_info(i)
             except Exception as e:
                 LOGGER.exception(e)
                 return


### PR DESCRIPTION
Our flow was:

- ask BlockInfo 1 from validator 
- ask BlockInfo 2 from validator
- ask Block 2 from validator
- ask BlockInfo 2 from validator
- ask BlockInfo 3 from validator
- ask Block 3 from validator
- ask BlockInfo 3 from validator
- ask BlockInfo 4 from validator
- ask Block 4 from validator
- etc...

If we have 100 blocks we have 299 requests (100 for Block and 199 for BlockInfo)

After this changes we will have 2 requests
- ask all BlockInfo from start to limit
- ask all Block from start + 1 to limit + 1

For getting all BlockInfo we could use list_state with parameters address, start and limit
![Screenshot from 2019-05-16 11-26-23](https://user-images.githubusercontent.com/35114937/57838530-8c752800-77cd-11e9-8d05-46c4f5ddf368.png)
For getting all Block we could use list_blocks with parameter start, limit and reverse
![Screenshot from 2019-05-16 11-26-16](https://user-images.githubusercontent.com/35114937/57838594-ab73ba00-77cd-11e9-9c08-43555683817d.png)

